### PR TITLE
feat: User-Agent header, Why Kyma section, live install banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,14 +101,34 @@ sudo apt install yt-dlp ffmpeg jq python3 curl
 export KYMA_API_KEY=kyma-xxxxxxxx
 ```
 
-`watch-cli` runs on **Kyma** for the audio side — one key that opens
-every gate (text, image, video, audio, and what comes next). Free credit
-at signup covers hundreds of videos.
-
-Get a Kyma key at [kymaapi.com](https://kymaapi.com).
+Get a Kyma key at [kymaapi.com](https://kymaapi.com) — 60 seconds, no card.
 
 Prefer bring-your-own-keys? Comment in `GROQ_API_KEY` and `GOOGLE_AI_KEY`
 in `.env.example` and watch-cli falls back to direct provider calls.
+
+---
+
+## Why Kyma
+
+watch-cli uses Kyma as its AI backend. A few things you get for free:
+
+![models](https://img.shields.io/endpoint?url=https://api.kymaapi.com/api/badge/models.json)
+![creators](https://img.shields.io/endpoint?url=https://api.kymaapi.com/api/badge/creators.json)
+![free credit](https://img.shields.io/endpoint?url=https://api.kymaapi.com/api/badge/free-credit.json)
+
+- **One key, every model in this CLI.** `transcribe` today is Whisper v3
+  turbo. When Kyma swaps in Voxtral or Whisper v4, your watch-cli scripts
+  keep working with zero changes — the alias stays.
+- **Per-call cost in the response.** Every transcribe gives you a real
+  number, not an end-of-month dashboard surprise.
+- **Auto-fallback across providers.** If the underlying audio provider is
+  throttling or down, Kyma routes through another. Your script never sees
+  the outage.
+- **Free credit at signup.** About an hour of audio. Enough to know if
+  you like it before you spend a cent.
+
+The badges above pull live from `api.kymaapi.com/api/stats`, so the model
+count and free-credit number stay current without a watch-cli release.
 
 ---
 

--- a/bin/audio-q
+++ b/bin/audio-q
@@ -76,6 +76,7 @@ case "$WATCH_AUDIO_MODE" in
     # Kyma can swap the underlying model without breaking watch-cli.
     RESP="$(curl -sS -X POST \
       -H "Authorization: Bearer $KYMA_API_KEY" \
+      -H "User-Agent: $WATCH_CLI_USER_AGENT" \
       -F "file=@$AUDIO;type=audio/mpeg" \
       -F "model=audio-understand" \
       -F "question=$QUESTION" \
@@ -109,6 +110,7 @@ case "$WATCH_AUDIO_MODE" in
     RESP="$(curl -sS -X POST \
       -H "Content-Type: application/json" \
       -H "x-goog-api-key: $GOOGLE_AI_KEY" \
+      -H "User-Agent: $WATCH_CLI_USER_AGENT" \
       -d "$BODY" \
       "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent")"
 

--- a/bin/models
+++ b/bin/models
@@ -38,7 +38,7 @@ fi
 BASE="${WATCH_KYMA_BASE:-https://api.kymaapi.com}"
 URL="$BASE/v1/models"
 
-RAW="$(curl -fsS "$URL" 2>&1)" || {
+RAW="$(curl -fsS -H "User-Agent: $WATCH_CLI_USER_AGENT" "$URL" 2>&1)" || {
   echo "[models] could not reach Kyma at $BASE" >&2
   echo "[models] check your internet, or set WATCH_KYMA_BASE if self-hosting" >&2
   exit 1

--- a/bin/transcribe
+++ b/bin/transcribe
@@ -79,6 +79,7 @@ case "$WATCH_AUDIO_MODE" in
     [[ -n "$LANG" ]] && ARGS+=(-F "language=$LANG")
     curl -sS -X POST \
       -H "Authorization: Bearer $KYMA_API_KEY" \
+      -H "User-Agent: $WATCH_CLI_USER_AGENT" \
       "${ARGS[@]}" \
       "$WATCH_KYMA_BASE/v1/audio/transcriptions"
     ;;
@@ -91,6 +92,7 @@ case "$WATCH_AUDIO_MODE" in
     [[ -n "$LANG" ]] && ARGS+=(-F "language=$LANG")
     curl -sS -X POST \
       -H "Authorization: Bearer $GROQ_API_KEY" \
+      -H "User-Agent: $WATCH_CLI_USER_AGENT" \
       "${ARGS[@]}" \
       https://api.groq.com/openai/v1/audio/transcriptions
     ;;

--- a/install.sh
+++ b/install.sh
@@ -75,8 +75,29 @@ if [[ ! -f "$ENV_FILE" ]]; then
   cp "$INSTALL_DIR/.env.example" "$ENV_FILE"
   green "✓ Created $ENV_FILE"
   echo
-  yellow "Next: get a Kyma API key at https://kymaapi.com"
+
+  # ── Kyma value-prop banner ──
+  # Pulled live from api.kymaapi.com/api/stats so the numbers stay current
+  # without a watch-cli release every time Kyma adds a model. Falls back to
+  # cached defaults if the gateway is unreachable.
+  KYMA_MODELS="50+"
+  KYMA_FREE="0.50"
+  if KYMA_STATS="$(curl -fsS --max-time 3 https://api.kymaapi.com/api/stats 2>/dev/null)"; then
+    KYMA_MODELS="$(printf '%s' "$KYMA_STATS" | jq -r '.models_count // "50+"' 2>/dev/null || echo "50+")"
+    KYMA_FREE="$(printf '%s' "$KYMA_STATS" | jq -r '.free_credit_usd // 0.50' 2>/dev/null || echo "0.50")"
+  fi
+
+  printf "\033[36m%s\033[0m\n" "🌊 Kyma — your AI key for everything in this CLI"
+  echo
+  echo "   ✓ One key for transcribe, audio Q&A, and ${KYMA_MODELS} other models"
+  echo "   ✓ \$${KYMA_FREE} free credit at signup (about an hour of audio)"
+  echo "   ✓ When Kyma swaps in newer models, your scripts keep working"
+  echo "   ✓ Auto-fallback when an upstream provider is down"
+  echo
+  yellow "Get key (60s, no card): https://kymaapi.com"
   echo "Then edit $ENV_FILE and set KYMA_API_KEY=…"
+  echo
+  dim "Prefer BYO keys? See $ENV_FILE for GROQ_API_KEY + GOOGLE_AI_KEY."
 else
   dim "  ($ENV_FILE already exists, leaving untouched)"
 fi

--- a/lib/env.sh
+++ b/lib/env.sh
@@ -18,6 +18,11 @@
 [[ -n "${WATCH_CLI_ENV_LOADED:-}" ]] && return 0
 export WATCH_CLI_ENV_LOADED=1
 
+# Version is sent in the User-Agent header so Kyma can attribute usage and
+# detect which install needs an upgrade. Bump on every release.
+export WATCH_CLI_VERSION="0.2.0"
+export WATCH_CLI_USER_AGENT="watch-cli/${WATCH_CLI_VERSION}"
+
 _load_dotenv() {
   local file="$1"
   [[ -f "$file" ]] || return 0


### PR DESCRIPTION
## Summary

PR 3 of the watch-cli/Kyma attribution series. Closes the loop so Kyma's agent classifier (kyma-api#334) can attribute usage to watch-cli on the rankings page, and so new users see the Kyma value prop the moment they install instead of guessing.

## What changed

### 1. Version + User-Agent header

\`lib/env.sh\` exports \`WATCH_CLI_VERSION=0.2.0\` and \`WATCH_CLI_USER_AGENT=watch-cli/0.2.0\`. Every curl call in \`bin/{transcribe,audio-q,models}\` now sends:

\`\`\`bash
-H \"User-Agent: \$WATCH_CLI_USER_AGENT\"
\`\`\`

Applied to both Kyma and Groq/Google direct paths.

### 2. Install banner with live numbers

\`install.sh\` post-install banner now pulls live numbers from \`https://api.kymaapi.com/api/stats\`:

\`\`\`
🌊 Kyma — your AI key for everything in this CLI

   ✓ One key for transcribe, audio Q&A, and 53 other models
   ✓ \$0.50 free credit at signup (about an hour of audio)
   ✓ When Kyma swaps in newer models, your scripts keep working
   ✓ Auto-fallback when an upstream provider is down

Get key (60s, no card): https://kymaapi.com
\`\`\`

Numbers stay current without watch-cli ever needing to release for them to update. Falls back to static defaults if the gateway is unreachable.

### 3. README \"Why Kyma\" section

Replaces the previous one-liner pitch with four standalone benefits:
- Model alias durability (\`transcribe\` keeps working when Kyma swaps in Voxtral/Whisper v4)
- Per-call cost in the response
- Auto-fallback across providers
- Free credit at signup

No comparison table — these are reasons to use Kyma on their own terms. Three live badges (models / creators / free credit) pull from \`/api/badge/*.json\` so the README never goes stale either.

## Why this matters

Before this PR, watch-cli sent the default \`curl/8.7.1\` User-Agent. Kyma's classifier couldn't tell watch-cli traffic apart from any other bash script and bucketed everyone as **\"cURL\"** on the rankings page.

With **0.2.0** installed, the next call from a watch-cli user will be tagged as **\"watch-cli\"** in Kyma's request_logs and surface on kymaapi.com/rankings.

Pre-0.2.0 users are still covered via Kyma's tier-2.5 fingerprint (\`curl + whisper-v3-turbo + /v1/audio/transcriptions → watch-cli\`) until they upgrade. So no user is left invisible regardless of release timing.

## Test plan

- [x] \`bash -n install.sh\` + all \`bin/*\` files — syntax valid
- [x] \`source lib/env.sh && echo \$WATCH_CLI_USER_AGENT\` → \`watch-cli/0.2.0\`
- [x] \`curl https://api.kymaapi.com/api/stats\` returns expected JSON — banner has live data to render
- [ ] After merge: \`./install.sh\` on a fresh \$HOME shows the new banner with live model count
- [ ] After merge: \`watch-cli\` user appears as \`agent_name=\"watch-cli\"\` in kyma-api \`request_logs\` within 1 call

🤖 Generated with [Claude Code](https://claude.com/claude-code)