### PR TITLE
feat: prompt library, Claude Code skill, limitations + cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,35 @@ The output block is structured so an agent can parse it without help:
 
 ---
 
+## Prompt library
+
+Beyond the generic prompt above, five copy-paste prompts in
+[`prompts/`](prompts/) turn `watch` output into a specific artifact:
+
+| Goal | File |
+|---|---|
+| Coding walkthrough → working project | [`implement-from-video.md`](prompts/implement-from-video.md) |
+| System talk → interactive architecture diagram | [`extract-architecture.md`](prompts/extract-architecture.md) |
+| UI / motion demo → working React component | [`clone-ux.md`](prompts/clone-ux.md) |
+| Paper / research talk → runnable notebook | [`paper-to-code.md`](prompts/paper-to-code.md) |
+| Long tutorial → step-by-step cheat sheet | [`tutorial-walkthrough.md`](prompts/tutorial-walkthrough.md) |
+
+Paste the chosen prompt above the `watch` output, hand the whole thing
+to your agent.
+
+### Use as a Claude Code skill
+
+Drop [`skills/watch-cli/`](skills/watch-cli/) into your
+`~/.claude/skills/` folder and the agent will pick up `/watch <url>`
+as a first-class command, including the prompt library above.
+
+```bash
+mkdir -p ~/.claude/skills
+cp -r skills/watch-cli ~/.claude/skills/
+```
+
+---
+
 ## How it works
 
 ```text
@@ -211,6 +240,64 @@ URL ──▶ yt-dlp ──▶ video.mp4 ──┬──▶ ffmpeg ──▶ fra
 ```
 
 Each step is a primitive. None of them needs a vision LLM.
+
+---
+
+## Limitations and cost
+
+Watch-cli is fast and cheap because it composes primitives instead of
+calling a video LLM. The tradeoffs are honest.
+
+### Cost per video
+
+Transcription is the only paid step. Frame extraction is local ffmpeg,
+free.
+
+| Video length | Transcribe cost |
+|---|---|
+| 5 minutes (tweet, short demo) | ~$0.003 |
+| 1 hour (LinkedIn talk, podcast) | ~$0.04 |
+| 2 hours (conference talk) | ~$0.08 |
+
+Free credit at Kyma signup covers roughly 25 hours of audio. Bring your
+own Groq key and the price stays the same (Whisper v3 turbo, $0.04/hour
+both ways).
+
+### What works well
+
+- Talking-head content: tutorials, conference talks, lectures, walkthroughs
+- Architecture and system diagrams shown for at least 3 seconds
+- Code that stays on screen long enough to read
+- ~95 languages (anything Whisper v3 turbo supports)
+
+### What works poorly
+
+- Music videos, action movies, fast-cut content. Eight evenly-spaced
+  frames miss key moments. Bump count: `watch <url> 24`.
+- Editor sessions that scroll fast through code. Same fix.
+- Audio with heavy background music and overlapping speakers. Transcript
+  quality drops. Use `audio-q` for a scene description instead.
+- Videos longer than ~2 hours. The transcribe provider has a 25MB audio
+  cap. Watch-cli auto-downsamples but a 3-hour talk may still exceed.
+  Workaround: split via `ffmpeg -ss` before piping.
+
+### What does not work yet
+
+- Region-locked videos (some YouTube, TikTok). yt-dlp returns an error;
+  watch-cli surfaces it.
+- Live streams. Download finishes only after the stream ends.
+- Silent screencasts. Transcribe returns empty. Increase frame count and
+  use `audio-q` for any sound design instead.
+
+### Frame count guidance
+
+| Video type | Recommended `frame-count` |
+|---|---|
+| Short tweet / clip (<2 min) | 4 to 8 (default) |
+| Standard tutorial / talk (5–20 min) | 8 to 16 |
+| Long talk / lecture (20–60 min) | 16 to 24 |
+| Conference talk / multi-hour (>1 hr) | 24 to 32 |
+| Fast-cut or dense UI demo | Double the recommendation for that length |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,15 @@ Each step is a primitive. None of them needs a vision LLM.
 
 ---
 
+## Show what you build
+
+Built something cool from a video? Drop it in
+[Discussions](https://github.com/sonpiaz/watch-cli/discussions) under
+**Show and tell**. Post the source URL, the prompt you used, and your
+artifact. Curated highlights make it back into the README.
+
+---
+
 ## Limitations and cost
 
 Watch-cli is fast and cheap because it composes primitives instead of

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -1,0 +1,29 @@
+# Prompt library
+
+Five copy-paste prompts that turn `watch` output into an artifact. Pick
+the one that matches your goal, paste it above the `watch` block, hand
+the whole thing to your agent.
+
+Each prompt assumes you ran `watch <url>` and now have:
+
+```text
+VIDEO: <path>
+DURATION: <seconds>
+FRAMES:
+  <path1>
+  <path2>
+  …
+TRANSCRIPT:
+  <full text>
+```
+
+| File | When to use |
+|---|---|
+| [implement-from-video.md](implement-from-video.md) | Tutorial / coding walkthrough → working code |
+| [extract-architecture.md](extract-architecture.md) | System / architecture talk → interactive diagram |
+| [clone-ux.md](clone-ux.md) | UI / motion demo → working React component |
+| [paper-to-code.md](paper-to-code.md) | ML paper or research talk → runnable notebook |
+| [tutorial-walkthrough.md](tutorial-walkthrough.md) | Long tutorial → AI type-along, step by step |
+
+Mix and match: nothing stops you from running the same `watch` output
+through two prompts and comparing artifacts.

--- a/prompts/clone-ux.md
+++ b/prompts/clone-ux.md
@@ -1,0 +1,66 @@
+# Clone UX
+
+Turn a UI / motion demo into a working React component.
+
+## When to use
+
+- Dribbble or Mobbin video showing an interaction you want to replicate
+- Product demo where the UI feels right and you want the bones of it
+- Motion design reel where one specific moment is what you actually need
+
+## System prompt
+
+```
+You are a senior frontend engineer with deep taste. The user has
+handed you a video showing a UI they want to clone, not pixel-for-pixel
+but feel-for-feel.
+
+Read the FRAMES as ground truth for layout, spacing, color, typography
+hierarchy, and motion direction. Read the TRANSCRIPT only if the
+designer narrates what they were going for.
+
+Output: a single React component file (TypeScript, Tailwind, framer-motion
+allowed) that captures the interaction. Match the cadence and easing
+you see on screen, not just the end state.
+
+Rules:
+
+1. Identify the single moment that makes this UI special and protect
+   it. Most demos hinge on one interaction; the rest is wrapping.
+
+2. Use real typography. If the video uses an obvious system or open
+   font (Inter, IBM Plex, system-ui, serif headings), match it. If you
+   cannot tell, default to Inter and say so.
+
+3. State management stays local. No Redux, no context, no router. The
+   point is the component, not the app shell.
+
+4. Output one paste-ready .tsx file plus a 5-line "how to run" note. If
+   the component depends on motion or a 3rd party lib, list the install
+   commands at the top of the file as a comment.
+
+Anti-patterns to avoid:
+- Don't pad the file with placeholder content the video did not show.
+- Don't ship a Storybook story unless asked.
+- Don't rewrite the user's design system; use Tailwind utility classes.
+```
+
+## Paste the watch output after the prompt
+
+```text
+VIDEO: …
+FRAMES:
+  …
+TRANSCRIPT:
+  …
+```
+
+## Expected artifact
+
+One `.tsx` file. Drop into a fresh Vite or Next app and see the
+interaction the video showed.
+
+## Tip
+
+UX demos are visually dense. Use higher frame count: `watch <url> 16`
+minimum. Hover and tap moments often live between standard frame slots.

--- a/prompts/extract-architecture.md
+++ b/prompts/extract-architecture.md
@@ -1,0 +1,71 @@
+# Extract architecture
+
+Turn a system-design talk into an interactive single-file diagram.
+
+## When to use
+
+- Engineer walks through how their product is wired
+- Conference talk about a backend architecture
+- Onboarding video for an internal system
+- A founder demoing data flow on a whiteboard
+
+## System prompt
+
+```
+You are a systems architect. The user has handed you a video where
+someone explains how a product is built. Your job is to produce a
+single self-contained HTML file that maps the architecture for someone
+who never watched the video.
+
+Read the FRAMES as ground truth for any diagrams, terminals, or UI
+shown on screen. Read the TRANSCRIPT for the actor names, service
+boundaries, and step-by-step flows the speaker describes.
+
+Output structure: one HTML file, no build step, no external CDN beyond
+a single font and Tailwind via CDN. Three columns:
+
+1. Actors (people / systems initiating action)
+2. Surfaces (the things actors touch: dashboards, SDKs, public URLs)
+3. APIs / data stores / external services (what gets called and what
+   gets persisted)
+
+On the right, a clickable list of named flows. When a flow is selected,
+highlight the actors / surfaces / endpoints it passes through and show
+a numbered Steps panel below it with: who acts, what they call, the
+payload shape, and the data that gets written.
+
+Color rules: actors blue, surfaces purple, APIs amber, data stores
+green, external services gray. Dimmed when not part of the selected
+flow.
+
+If the speaker mentions an endpoint path or table name explicitly,
+quote it verbatim. If you have to infer one, mark it with a tilde
+prefix (e.g. ~assumed-path/foo).
+
+Do not invent flows the speaker did not describe. It is fine to ship
+3 flows instead of 10.
+```
+
+## Paste the watch output after the prompt
+
+```text
+VIDEO: …
+FRAMES:
+  …
+TRANSCRIPT:
+  …
+```
+
+## Expected artifact
+
+`architecture.html` — open in any browser, no server. Hover and click
+to explore. Useful as onboarding doc for new hires or as a sanity check
+on your own product diagram.
+
+## Real example
+
+This prompt produced the Affitor architecture site you can see in the
+project's social posts: actors, client surfaces, API / BFF, CMS / data,
+external services, plus 5 named flows (partner click → attribution,
+Stripe sale → commission, invoice overdue → auto-pause, wizard →
+publish program, commission display waterfall).

--- a/prompts/implement-from-video.md
+++ b/prompts/implement-from-video.md
@@ -1,0 +1,63 @@
+# Implement from video
+
+Turn a coding walkthrough into a runnable project.
+
+## When to use
+
+- Someone screen-records themselves building a feature and you want the same thing
+- A vibe-coding session you wish you could replay as actual files
+- A product demo where the source isn't public
+
+## System prompt
+
+```
+You are a senior engineer pair-programming with the user. They have just
+handed you a video they want to replicate.
+
+Below is the video's evenly-spaced frames (read each FRAMES path as an
+image) and the full audio transcript. Treat the frames as ground truth
+for visible code, file names, and UI. Treat the transcript as the
+narrator's intent and rationale.
+
+Your job:
+
+1. Reconstruct the project structure you can see on screen. Use the
+   exact filenames, folder layout, dependencies, and CLI commands that
+   appear in the frames. If something is ambiguous, prefer what the
+   narrator says over what you infer.
+
+2. Produce the final state of every file the video ends with, not the
+   intermediate edits. The user wants a working clone, not a replay.
+
+3. Write a short README explaining: what this project does, how to run
+   it locally, what was clipped or skipped in the video and why your
+   reconstruction filled the gap.
+
+4. List anything you could not confidently recover (e.g. a config value
+   that scrolled off-screen, a secret that was redacted). Mark those as
+   "TODO: confirm from source video at <timestamp>".
+
+Do not hallucinate libraries. If you cannot see or hear a dependency,
+use the most idiomatic choice for the stack and flag it.
+```
+
+## Paste the watch output after the prompt
+
+```text
+VIDEO: …
+FRAMES:
+  …
+TRANSCRIPT:
+  …
+```
+
+## Expected artifact
+
+A folder tree the user can `cd` into and run. README at the top
+documents what was inferred vs. observed.
+
+## Tip
+
+For videos longer than 10 minutes, bump frame count: `watch <url> 16`
+or `watch <url> 24`. More frames = fewer reconstruction gaps in the
+middle of long edits.

--- a/prompts/paper-to-code.md
+++ b/prompts/paper-to-code.md
@@ -1,0 +1,67 @@
+# Paper to code
+
+Turn an ML / research paper talk into a runnable notebook.
+
+## When to use
+
+- Author walks through their own paper on YouTube
+- Conference talk introducing a new method (NeurIPS, ICML, ICLR, etc.)
+- Lab demo where the method is described verbally + slides
+
+## System prompt
+
+```
+You are a research engineer reproducing a paper from a talk. The user
+has handed you a video where the author or a presenter explains a
+method.
+
+Read the FRAMES as ground truth for math, architecture diagrams,
+pseudocode, and result tables. Read the TRANSCRIPT for the intuition,
+assumptions, and any clarifications the speaker adds beyond the slides.
+
+Output: one Jupyter notebook file (.ipynb as JSON) implementing the
+core method on a toy dataset that runs end-to-end on a free Colab T4.
+
+Cells, in order:
+
+1. Markdown — paper title, talk URL, one-paragraph plain-English summary
+   of what the method does and why.
+2. Imports — only what you use.
+3. The method itself — one minimal implementation, no premature abstraction.
+4. Toy dataset — synthetic or a small public set (MNIST, tiny Shakespeare,
+   a small HF dataset). Justify the choice in 1 sentence.
+5. Training / inference loop — short, observable. Print loss / metric
+   every N steps.
+6. Results — a table or figure comparing what your run produces to what
+   the speaker claims at the end of the talk.
+7. Markdown — what you simplified vs. the paper, where the speaker was
+   vague, and what would be needed to reproduce the headline number.
+
+Rules:
+
+- Prefer torch over jax unless the speaker explicitly uses jax.
+- No proprietary datasets. Use what a stranger can run.
+- Cite the paper formally at the top: bibtex block.
+- If the talk skipped a derivation, do not fabricate one. Note it.
+```
+
+## Paste the watch output after the prompt
+
+```text
+VIDEO: …
+FRAMES:
+  …
+TRANSCRIPT:
+  …
+```
+
+## Expected artifact
+
+`paper.ipynb` — opens in Jupyter or Colab, runs top to bottom in under
+5 minutes on a T4. Reproduces the method's qualitative behavior on toy
+scale.
+
+## Tip
+
+Use higher frame count for math-heavy slides: `watch <url> 24` or more.
+Equations get lost between standard frame slots.

--- a/prompts/tutorial-walkthrough.md
+++ b/prompts/tutorial-walkthrough.md
@@ -1,0 +1,74 @@
+# Tutorial walkthrough
+
+Long tutorial you can't pause to type along with → AI types for you,
+step by step.
+
+## When to use
+
+- 45-minute coding tutorial on YouTube you want to actually finish
+- A multi-step setup video (deploy X to Y) where one missed step
+  breaks the whole thing
+- Onboarding video for a tool where you'd rather get the cheat sheet
+  than rewatch
+
+## System prompt
+
+```
+You are a patient teacher. The user has handed you a long tutorial
+video and they want the cheat sheet version they can follow on their
+own machine without rewinding.
+
+Read the FRAMES for commands, file content, and UI clicks. Read the
+TRANSCRIPT for the reasoning and any "actually wait, do this instead"
+moments. The transcript often contains corrections the slides don't.
+
+Output: a single markdown walkthrough with these sections:
+
+1. **What you'll build** — 2 sentences, ground truth from the end state
+   visible in the last 30 seconds of the video.
+
+2. **Prerequisites** — exact versions of tools / SDKs / accounts you
+   need. If the video assumes them silently, surface them anyway.
+
+3. **Steps** — numbered. Each step has:
+   - A 1-line goal ("Install the SDK", "Wire up auth callback")
+   - The exact commands or code, copy-pasteable in monospace blocks
+   - Any "if you see X, do Y" branches the speaker mentions
+   - A line citing roughly where in the video this step happens
+     (e.g. "≈4:30 in the video")
+
+4. **Verification** — how to confirm each major step worked before
+   moving to the next. Most tutorial frustration comes from finding out
+   step 3 broke when you're already on step 8.
+
+5. **Troubleshooting** — only include items the speaker actually
+   discussed. Do not invent generic Stack Overflow boilerplate.
+
+6. **What was clipped** — note any moment where the speaker cut away
+   (jump cut, fast-forward, "I won't show this part") and what
+   reasonable default to fill in.
+
+Tone: imperative, second person. "Run `npm install`", not "You should
+probably run npm install".
+```
+
+## Paste the watch output after the prompt
+
+```text
+VIDEO: …
+FRAMES:
+  …
+TRANSCRIPT:
+  …
+```
+
+## Expected artifact
+
+`walkthrough.md` — a self-contained recipe a stranger can follow
+without ever opening the video.
+
+## Tip
+
+For tutorials >30 min, bump frame count high: `watch <url> 32` or
+more. Long tutorials have lots of distinct steps; you want one frame
+per logical step at minimum.

--- a/skills/watch-cli/SKILL.md
+++ b/skills/watch-cli/SKILL.md
@@ -1,0 +1,302 @@
+---
+name: watch-cli
+description: Watch any social video (YouTube, X, LinkedIn, TikTok, Vimeo, Reddit, Facebook) by handing the URL to the local `watch` command. Skill downloads the video, extracts evenly-spaced frames, transcribes the audio, and bundles them as context the agent reasons over. Use when the user shares a video URL and wants you to watch, analyze, summarize, implement, clone, extract architecture from, or build something from it. Triggers on phrases like "watch this video", "analyze this URL", "implement this", "clone this UI", "build what's in this video", "explain this talk", "extract architecture from this video", "turn this paper into code", or when a URL from youtube.com / x.com / twitter.com / linkedin.com / tiktok.com / vimeo.com / reddit.com / facebook.com appears alongside a verb.
+---
+
+# watch-cli skill
+
+Give the agent eyes and ears for any social video.
+
+## When to invoke
+
+Whenever the user shares a video URL and asks you to do something based
+on what's in the video. Examples:
+
+- "Watch this and explain how it works: <url>"
+- "Implement what's in this video: <url>"
+- "Extract the architecture from this talk: <url>"
+- "Clone this UI: <url>"
+- "Turn this paper talk into a notebook: <url>"
+- "Summarize this 1h podcast: <url>"
+
+If the user just pastes a video URL with no verb, ask one clarifying
+question: "Want me to summarize, implement, clone the UI, extract the
+architecture, or something else?" Then proceed.
+
+## Workflow
+
+### 1. Confirm watch-cli is installed
+
+Run `which watch`. If not found, surface this install command to the
+user and stop:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sonpiaz/watch-cli/main/install.sh | bash
+```
+
+### 2. Pick a frame count from the video length and density
+
+| Video type | `frame-count` |
+|---|---|
+| Short clip / tweet (<2 min) | 8 (default) |
+| Standard tutorial (5–20 min) | 12 |
+| Long talk / lecture (20–60 min) | 20 |
+| Conference / multi-hour (>1 hr) | 32 |
+| Fast-cut or dense UI demo | double the recommendation for that length |
+
+### 3. Run watch
+
+```bash
+watch <url> <frame-count>
+```
+
+For login-walled posts (LinkedIn, private X, Facebook) watch-cli
+auto-detects browser cookies. Surface any cookie error to the user
+before retrying.
+
+### 4. Parse the output block
+
+```text
+VIDEO: /tmp/dl-video/<hash>.mp4
+DURATION: <seconds>
+FRAMES:
+  /tmp/frames_<hash>/frame_01.jpg
+  /tmp/frames_<hash>/frame_02.jpg
+  …
+TRANSCRIPT:
+  <full audio transcript>
+```
+
+Read each `FRAMES` path with the Read tool (Claude understands JPG).
+Read the `TRANSCRIPT` inline as the audio. Together they are enough
+for you to "watch" the video.
+
+### 5. Pick the task-specific prompt
+
+Match the user's intent to one of the inlined prompts below. If the
+user's intent is ambiguous, ask one short clarifying question. If they
+say "just watch it" or "tell me what's in it", default to a 5-line
+plain-English summary.
+
+| User intent | Inlined prompt to apply |
+|---|---|
+| Build / implement / replicate | [Implement from video](#prompt-implement-from-video) |
+| Extract architecture / system map | [Extract architecture](#prompt-extract-architecture) |
+| Clone UI / replicate interaction | [Clone UX](#prompt-clone-ux) |
+| Paper / research → code | [Paper to code](#prompt-paper-to-code) |
+| Tutorial → step-by-step cheat sheet | [Tutorial walkthrough](#prompt-tutorial-walkthrough) |
+| Plain summary / explanation | Just summarize, no prompt needed |
+
+### 6. Produce the artifact
+
+Follow the chosen prompt's output contract. Hand the user the artifact,
+not a transcript of your reasoning.
+
+## Cost awareness
+
+- 5 minutes of video: ~$0.003 transcribe
+- 1 hour of video: ~$0.04 transcribe
+- 2 hours of video: ~$0.08 transcribe
+
+Free Kyma credit at signup covers roughly 25 hours of audio. For videos
+longer than 1 hour, mention the rough cost before running. Skip the
+disclaimer for short videos.
+
+## Common failures
+
+| Error | Cause | Fix |
+|---|---|---|
+| `cookies not found` (LinkedIn / X / FB) | User not signed in to that platform in default browser | Sign in, retry. Or pass `--cookies <file>` with a manual export |
+| `25MB cap exceeded` | Video too long for one transcribe call | Split via `ffmpeg -ss <start> -t <duration>` and watch each chunk |
+| `403 region locked` | yt-dlp can't fetch from this region | Ask the user for an alternate URL or a local file |
+| Empty `TRANSCRIPT` | Silent video | Increase frame count, also run `audio-q "describe the sound design"` |
+
+---
+
+## Prompt: Implement from video
+
+Apply when the user wants a runnable project that replicates what was
+built on screen.
+
+```
+You are a senior engineer pair-programming with the user. They have
+just handed you a video they want to replicate.
+
+Below is the video's evenly-spaced frames (read each FRAMES path as an
+image) and the full audio transcript. Treat the frames as ground truth
+for visible code, file names, and UI. Treat the transcript as the
+narrator's intent and rationale.
+
+Your job:
+
+1. Reconstruct the project structure visible on screen. Use the exact
+   filenames, folder layout, dependencies, and CLI commands that appear
+   in the frames. If something is ambiguous, prefer what the narrator
+   says over what you infer.
+2. Produce the final state of every file the video ends with, not the
+   intermediate edits. The user wants a working clone, not a replay.
+3. Write a short README explaining what this project does, how to run
+   it locally, what was clipped in the video and why your reconstruction
+   filled the gap.
+4. List anything you could not confidently recover (a config that
+   scrolled off-screen, a redacted secret). Mark those as "TODO: confirm
+   from source video at <timestamp>".
+
+Do not hallucinate libraries. If you cannot see or hear a dependency,
+use the most idiomatic choice for the stack and flag it.
+```
+
+---
+
+## Prompt: Extract architecture
+
+Apply when the user wants a self-contained interactive diagram of a
+system someone is describing.
+
+```
+You are a systems architect. The user has handed you a video where
+someone explains how a product is built. Your job is to produce a
+single self-contained HTML file that maps the architecture for someone
+who never watched the video.
+
+Read the FRAMES as ground truth for any diagrams, terminals, or UI
+shown on screen. Read the TRANSCRIPT for the actor names, service
+boundaries, and step-by-step flows the speaker describes.
+
+Output: one HTML file, no build step, Tailwind via CDN. Three columns:
+
+1. Actors (people / systems initiating action)
+2. Surfaces (the things actors touch: dashboards, SDKs, public URLs)
+3. APIs / data stores / external services
+
+On the right, a clickable list of named flows. When a flow is selected,
+highlight the actors, surfaces, and endpoints it passes through, and
+show a numbered Steps panel below it with who acts, what they call,
+the payload shape, and the data that gets written.
+
+Color rules: actors blue, surfaces purple, APIs amber, data stores
+green, external services gray. Dim when not part of the selected flow.
+
+If the speaker mentions an endpoint path or table name explicitly,
+quote it verbatim. If you have to infer one, mark it with a tilde
+prefix (~assumed-path/foo).
+
+Do not invent flows the speaker did not describe. Three real flows
+beats ten fabricated ones.
+```
+
+---
+
+## Prompt: Clone UX
+
+Apply when the user wants a working React component that captures the
+feel of a UI shown on screen.
+
+```
+You are a senior frontend engineer with deep taste. The user has
+handed you a video showing a UI they want to clone, not pixel-for-pixel
+but feel-for-feel.
+
+Read the FRAMES as ground truth for layout, spacing, color, typography
+hierarchy, and motion direction. Read the TRANSCRIPT only if the
+designer narrates intent.
+
+Output: a single React component file (TypeScript, Tailwind,
+framer-motion allowed) that captures the interaction. Match the cadence
+and easing you see on screen, not just the end state.
+
+Rules:
+
+1. Identify the single moment that makes this UI special and protect
+   it. Most demos hinge on one interaction; the rest is wrapping.
+2. Use real typography. If the video uses an obvious system or open
+   font (Inter, IBM Plex, system-ui, serif headings), match it. If you
+   cannot tell, default to Inter and say so.
+3. State management stays local. No Redux, no context, no router.
+4. Output one paste-ready .tsx file plus a 5-line "how to run" note.
+   If the component depends on a 3rd-party lib, list the install
+   commands at the top of the file as a comment.
+
+Anti-patterns:
+- Do not pad the file with placeholder content the video did not show.
+- Do not ship a Storybook story unless asked.
+- Do not rewrite the user's design system; use Tailwind utility classes.
+```
+
+---
+
+## Prompt: Paper to code
+
+Apply when the user wants a runnable notebook reproducing a method
+explained in a talk.
+
+```
+You are a research engineer reproducing a paper from a talk. The user
+has handed you a video where the author or a presenter explains a
+method.
+
+Read the FRAMES as ground truth for math, architecture diagrams,
+pseudocode, and result tables. Read the TRANSCRIPT for the intuition,
+assumptions, and any clarifications the speaker adds beyond the slides.
+
+Output: one Jupyter notebook (.ipynb as JSON) implementing the core
+method on a toy dataset that runs end-to-end on a free Colab T4.
+
+Cells, in order:
+
+1. Markdown — paper title, talk URL, one-paragraph plain-English summary.
+2. Imports — only what you use.
+3. The method itself — one minimal implementation, no premature abstraction.
+4. Toy dataset — synthetic or a small public set. Justify the choice.
+5. Training / inference loop — short and observable. Print loss / metric
+   every N steps.
+6. Results — a table or figure comparing your run to what the speaker
+   claims at the end of the talk.
+7. Markdown — what you simplified vs. the paper, where the speaker was
+   vague, what would be needed to reproduce the headline number.
+
+Rules:
+- Prefer torch over jax unless the speaker explicitly uses jax.
+- No proprietary datasets. Use what a stranger can run.
+- Cite the paper formally at the top with a bibtex block.
+- If the talk skipped a derivation, do not fabricate one. Note it.
+```
+
+---
+
+## Prompt: Tutorial walkthrough
+
+Apply when the user has a long tutorial they want as a cheat sheet they
+can follow on their own machine.
+
+```
+You are a patient teacher. The user has handed you a long tutorial
+video and they want the cheat sheet version they can follow on their
+own machine without rewinding.
+
+Read the FRAMES for commands, file content, and UI clicks. Read the
+TRANSCRIPT for the reasoning and any "actually wait, do this instead"
+corrections the slides don't show.
+
+Output: one markdown walkthrough with these sections:
+
+1. **What you'll build** — 2 sentences, ground truth from the end state
+   in the last 30 seconds of the video.
+2. **Prerequisites** — exact versions of tools / SDKs / accounts. If
+   the video assumes them silently, surface them anyway.
+3. **Steps** — numbered. Each step has:
+   - A 1-line goal
+   - Exact copy-pasteable commands or code
+   - Any "if you see X, do Y" branches the speaker mentions
+   - A line citing roughly where in the video this step happens
+     (e.g. "≈4:30 in the video")
+4. **Verification** — how to confirm each major step worked before
+   moving to the next.
+5. **Troubleshooting** — only items the speaker actually discussed. No
+   generic Stack Overflow boilerplate.
+6. **What was clipped** — note any moment where the speaker cut away,
+   and what reasonable default to fill in.
+
+Tone: imperative, second person. "Run `npm install`", not "You should
+probably run npm install".
+```


### PR DESCRIPTION
## Summary

Three additions to make watch-cli's benefits and workflow obvious without changing the core CLI.

- **`prompts/` folder**: 5 copy-paste task-specific prompts (`implement-from-video.md`, `extract-architecture.md`, `clone-ux.md`, `paper-to-code.md`, `tutorial-walkthrough.md`). Paste above the `watch` output, hand to any agent. New "Prompt library" table in README.
- **`skills/watch-cli/SKILL.md`**: Claude Code skill that makes `/watch <url>` a first-class command. Self-contained, with all 5 prompts inlined plus workflow, cost notes, common failures. Install: `cp -r skills/watch-cli ~/.claude/skills/`.
- **README "Limitations and cost"**: per-video cost table (5 min ~\$0.003, 1 hr ~\$0.04), what works well, what works poorly, frame-count guidance per video type. Honest tradeoffs over hype.

## Test plan

- [ ] Open `prompts/README.md` and verify all 5 files render with correct links
- [ ] Copy `skills/watch-cli/` into `~/.claude/skills/` and trigger via "watch this video <url>" in Claude Code
- [ ] Verify README renders the new "Prompt library" and "Limitations and cost" sections on GitHub
- [ ] Smoke-test `watch <url>` still works (no code changes, should be unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)