### PR TITLE
fix(dl-video): pass JS runtime + alt YouTube player_clients to yt-dlp

### DIFF
--- a/bin/dl-video
+++ b/bin/dl-video
@@ -70,6 +70,11 @@ fi
 FORMAT='best[height<=720]/best'
 
 run_dl() {
+  local -a EXTRA=()
+  if command -v node >/dev/null 2>&1; then
+    EXTRA+=(--js-runtimes "node:$(command -v node)")
+  fi
+  EXTRA+=(--extractor-args "youtube:player_client=web_safari,mweb,android_vr,ios")
   yt-dlp \
     --no-playlist \
     --no-warnings \
@@ -77,6 +82,7 @@ run_dl() {
     --merge-output-format mp4 \
     -f "$FORMAT" \
     -o "$OUT" \
+    "${EXTRA[@]}" \
     "$@" \
     "$URL" >&2
 }


### PR DESCRIPTION
## Summary

`dl-video` currently fails on YouTube with `ERROR: [youtube] <id>: Requested format is not available` on systems where:
- **Deno isn't installed** (yt-dlp's only auto-enabled JS runtime), and/or
- **The user is signed into Google** (default `tv_downgraded` / `web_creator` clients now demand a Data Sync ID).

yt-dlp can only emit storyboard images in that state, so the download silently degrades. Symptoms reported elsewhere: [yt-dlp#11904](https://github.com/yt-dlp/yt-dlp/issues/11904), [#11932](https://github.com/yt-dlp/yt-dlp/issues/11932).

This PR adds two flags to the existing `run_dl` invocation:

- `--js-runtimes node:$(command -v node)` — only when `node` is on PATH. Lets yt-dlp solve YouTube's obfuscated `n` parameter without requiring a Deno install.
- `--extractor-args "youtube:player_client=web_safari,mweb,android_vr,ios"` — forces clients that don't need a Data Sync ID.

Both are scoped — `node` check prevents regressions on Deno-equipped systems, and the extractor-args namespace (`youtube:`) leaves TikTok/X/Vimeo/LinkedIn extraction unchanged.

## Why these specific clients

`web_safari`, `mweb`, `android_vr`, and `ios` are the player clients currently confirmed by the yt-dlp project to bypass the Data Sync ID requirement while still exposing the full mp4/webm format ladder (135–401, including 480p–4K progressive variants). I chose four rather than one to give yt-dlp fallback room as YouTube rotates restrictions.

## Test plan

- [ ] Run `watch <youtube-url>` on a video that previously failed with "Requested format is not available" — confirm it now downloads.
- [ ] Run `watch <tiktok-url>` and `watch <vimeo-url>` — confirm non-YouTube hosts still work (extractor-args is youtube-only namespace).
- [ ] On a system without `node` installed (Deno-only), confirm no warnings appear about the missing runtime flag.

## Notes

Tested on WSL2 Ubuntu, yt-dlp 2026.03.17, Node 22.x at `~/.local/bin/node`. The same fix should apply on macOS — `command -v node` resolves Homebrew/nvm installs equally.

Happy to adjust the player_client list if you'd prefer a smaller set, or to gate the extractor-args behind a `[[ "$URL" == *youtube* ]]` check if you want it strictly opt-in for YT URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)