### PR TITLE
docs(readme): reframe Benchmark as Why pay-per-use

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,20 @@ posts (LinkedIn, X, FB) fall back to your browser cookies automatically.
 ## Why this exists
 
 Large language models can't watch video natively — they read text and
-look at still images. Modern multimodal APIs *will* analyze a full video
-for you, but they're slow and expensive. The trick: **you almost never
-need them**.
+look at still images. You can hand a video to a multimodal API and get
+back a chat-style summary, but for an agent workflow that's the wrong
+artifact: the agent wants the raw frames and the full transcript so it
+can reason for itself, not someone else's pre-digested recap.
 
-A video is just frames + audio. Each piece has a fast, near-free tool
-already:
+A video is just frames + audio, and each piece already has a fast,
+near-free primitive:
 
 - `yt-dlp` downloads from any social platform
 - `ffmpeg` extracts evenly-spaced frames
 - An ASR model transcribes the audio
 - A multimodal LLM hears tone, music, SFX, language, mood
 
-Compose them and your agent has video understanding — without burning a
-multimodal LLM on every frame.
+Compose them and your agent has the materials to watch any social video.
 
 ---
 
@@ -53,17 +53,25 @@ Your agent reads the JPGs and the transcript. That's the whole watch.
 
 ---
 
-## Benchmark
+## Why pay-per-use, not subscription
 
-After noticing how much we burned on multimodal calls, we measured:
+Most subscription summary tools start around **$15/month** and deliver a
+polished, human-readable summary. If you're feeding an AI agent, that's the
+wrong artifact — agents need raw frames and the full transcript to reason
+for themselves, not someone else's pre-digested recap.
 
-| Approach | Cost / 1-hour video | Time |
-|---|---|---|
-| Multimodal LLM on full video | ~$5 | 30–60s |
-| watch-cli (Kyma audio) | < $0.10 | ~10–15s |
-| **Ratio** | **~50× cheaper** | **~5× faster** |
+A typical research session is 1–3 videos, not 100. Through Kyma — the default
+backend — a 1-hour video costs **~$0.04** (transcribe is the only paid step;
+frame extraction is local ffmpeg).
 
-The savings compound when an agent watches dozens of videos in a session.
+| This month you watch | You pay |
+|---|---|
+| 0 videos | $0 |
+| 1 one-hour video | ~$0.04 |
+| 100 one-hour videos | ~$4 |
+
+No monthly minimum, no seat license, no lock-in. The free credit at Kyma
+signup is enough to run the full pipeline end-to-end before you spend a cent.
 
 ---
 


### PR DESCRIPTION
## Summary

Replaces the **Benchmark** section (which claimed a multimodal LLM costs ~\$5/1-hr video and watch-cli is "50× cheaper") with a **Why pay-per-use, not subscription** narrative.

The previous framing was off for two reasons:
1. The \$5 anchor was ungrounded — Gemini 1.5 Pro native video sits around \$1.16/hr; the only way to hit \$5 is GPT-4o frame-sampling worst-case. Either way, it read as a competitor-swipe rather than a clean positioning.
2. The audience watch-cli actually competes with isn't "people calling raw multimodal APIs" — it's people paying ~\$15/month for a subscription summary tool (Otter/Notta/Eightify-class).

The new section anchors against that subscription baseline, keeps Kyma as the primary backend, and shows the pay-per-use math directly:

| This month you watch | You pay |
|---|---|
| 0 videos | \$0 |
| 1 one-hour video | ~\$0.04 |
| 100 one-hour videos | ~\$4 |

Also softens the **Why this exists** intro to frame the difference as **artifact mismatch** (chat-style summary vs raw frames+transcript) rather than "multimodal APIs are slow and expensive" — the previous phrasing read as a swipe and invited price-comparison rebuttals.

## What did NOT change
- Setup section keeps \`KYMA_API_KEY\` as the primary path.
- "Why Kyma" section (bullets about aliases, auto-fallback, free credit) untouched.
- BYOK remains a one-liner escape hatch.
- Cost table in "Limitations and cost" section (\$0.003 / \$0.04 / \$0.08) unchanged — those numbers are accurate.

## Flag for separate decision

Existing README has a **free-credit discrepancy** I didn't touch in this PR:
- Line ~128 (Why Kyma section): *"Free credit at signup. About an hour of audio."*
- Line ~271 (Limitations section): *"Free credit at Kyma signup covers roughly 25 hours of audio."*

At \$0.04/hr transcribe, \$0.50 free credit ≈ ~12 hours. Both existing numbers are wrong in opposite directions. Recommend a follow-up PR aligning both to a single accurate number (~12 hours or whatever the current free-credit policy actually is) — separate from this positioning change.

## Test plan
- [ ] Render README on GitHub and confirm tables/headings format correctly
- [ ] Skim the section transitions (Why this exists → What it looks like → Why pay-per-use → Install) — flow makes sense
- [ ] Cross-check that no other section references "Benchmark" or the "50× cheaper" claim