### PR TITLE
docs(readme): align prices to Kyma list, strip provider names from top

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ wrong artifact — agents need raw frames and the full transcript to reason
 for themselves, not someone else's pre-digested recap.
 
 A typical research session is 1–3 videos, not 100. Through Kyma — the default
-backend — a 1-hour video costs **~$0.04** (transcribe is the only paid step;
+backend — a 1-hour video costs **~$0.05** (transcribe is the only paid step;
 frame extraction is local ffmpeg).
 
 | This month you watch | You pay |
 |---|---|
 | 0 videos | $0 |
-| 1 one-hour video | ~$0.04 |
-| 100 one-hour videos | ~$4 |
+| 1 one-hour video | ~$0.05 |
+| 100 one-hour videos | ~$5 |
 
 No monthly minimum, no seat license, no lock-in. The free credit at Kyma
 signup is enough to run the full pipeline end-to-end before you spend a cent.
@@ -124,16 +124,16 @@ watch-cli uses Kyma as its AI backend. A few things you get for free:
 ![creators](https://img.shields.io/endpoint?url=https://api.kymaapi.com/api/badge/creators.json)
 ![free credit](https://img.shields.io/endpoint?url=https://api.kymaapi.com/api/badge/free-credit.json)
 
-- **One key, every model in this CLI.** `transcribe` today is Whisper v3
-  turbo. When Kyma swaps in Voxtral or Whisper v4, your watch-cli scripts
-  keep working with zero changes — the alias stays.
+- **One key, every model in this CLI.** watch-cli calls Kyma using
+  capability aliases (`transcribe`, `audio-understand`). When Kyma swaps
+  in a better model behind the alias, your scripts keep working unchanged.
 - **Per-call cost in the response.** Every transcribe gives you a real
   number, not an end-of-month dashboard surprise.
 - **Auto-fallback across providers.** If the underlying audio provider is
   throttling or down, Kyma routes through another. Your script never sees
   the outage.
-- **Free credit at signup.** About an hour of audio. Enough to know if
-  you like it before you spend a cent.
+- **Free credit at signup.** About 9 hours of audio at the default rate.
+  Enough to know if you like it before you spend a cent.
 
 The badges above pull live from `api.kymaapi.com/api/stats`, so the model
 count and free-credit number stay current without a watch-cli release.
@@ -272,13 +272,12 @@ free.
 
 | Video length | Transcribe cost |
 |---|---|
-| 5 minutes (tweet, short demo) | ~$0.003 |
-| 1 hour (LinkedIn talk, podcast) | ~$0.04 |
-| 2 hours (conference talk) | ~$0.08 |
+| 5 minutes (tweet, short demo) | ~$0.005 |
+| 1 hour (LinkedIn talk, podcast) | ~$0.05 |
+| 2 hours (conference talk) | ~$0.11 |
 
-Free credit at Kyma signup covers roughly 25 hours of audio. Bring your
-own Groq key and the price stays the same (Whisper v3 turbo, $0.04/hour
-both ways).
+Free credit at Kyma signup covers about 9 hours of transcribe. A BYOK
+path is available — see `.env.example`.
 
 ### What works well
 


### PR DESCRIPTION
## Summary

Two integrity fixes spotted after PR #6 merged:

### 1. Pricing — actual user-facing list, not provider cost

watch-cli was quoting **\$0.04/hour** everywhere. That's the Groq provider cost. After Kyma's \`AUDIO_MARKUP = 1.35\` (per \`kyma-api/src/credits.ts:466\`), the list price the user actually pays is **\$0.054/hour**.

A user signing up after reading "watch a 1-hour video for ~\$0.04" then getting billed \$0.054 is a 35% surprise.

Updated to list rate everywhere it appears:
- Why-pay-per-use table: \$0.04 → \$0.05, \$4 → \$5
- Cost-per-video table: \$0.003 / \$0.04 / \$0.08 → \$0.005 / \$0.05 / \$0.11
- Free credit hours aligned to math (\$0.50 / \$0.054 ≈ 9): both inconsistent claims ("about an hour", "roughly 25 hours") replaced with **about 9 hours**.

Still very cheap — that's the point. Just accurate.

### 2. Strip provider/model names from top-of-page value-prop

\`Why Kyma\` bullet 1 was naming "Whisper v3 turbo / Voxtral / Whisper v4" — too plumbing-heavy for what is essentially a marketing bullet. Replaced with the capability-alias narrative.

Deeper technical sections keep model mentions (per [your call](#) — model names are fine when discussing the alias-stability mechanism, How-it-works diagram, language coverage). The principle is: top of README stays clean from internal plumbing.

### 3. Drop the Groq price-equality claim

Existing line in Limitations: *"Bring your own Groq key and the price stays the same (Whisper v3 turbo, \$0.04/hour both ways)."*

Two problems:
- Named a backend provider explicitly in a value-prop position
- Implied price equality with Kyma (\$0.04 vs \$0.054) that doesn't hold

Replaced with neutral BYOK pointer: *"A BYOK path is available — see \`.env.example\`."*

## What did NOT change
- Setup section keeps Kyma as the primary path
- \`.env.example\` content untouched
- \`How it works\` diagram + \`How transcribe stays current\` subsection keep model names — they're the right place for plumbing detail
- \`What works well\` keeps "(anything Whisper v3 turbo supports)" — deep technical context

## Test plan
- [ ] Skim rendered README on GitHub, confirm all \$0.04 → \$0.05 swaps and tables format correctly
- [ ] Grep diff for any remaining \$0.04 / 25 hours / 1 hour claim
- [ ] Sanity check that Why-pay-per-use math still adds up (0/0, 1/\$0.05, 100/\$5)