### PR TITLE
docs(phase-0): lock pitch around U1 + U2, add BRANDING.md

### DIFF
--- a/BRANDING.md
+++ b/BRANDING.md
@@ -1,0 +1,64 @@
+# Branding & messaging
+
+Single source of truth for how watch-cli describes itself. Anyone writing user-facing copy — README, `SKILL.md`, MCP server descriptions, listing PRs, social posts — should read this first.
+
+## Mission
+
+watch-cli is the thin orchestrator that hands AI agents the raw materials to reason over any social video.
+
+## Locked one-line pitch
+
+> **Watch any social video → get an architecture diagram, working component, runnable notebook, or step-by-step cheat sheet — automatically.**
+
+Use this line (or a tight variant that keeps the *video → concrete artifact* mapping) as the lead in any user-facing description. Don't dilute with adjectives. Don't move the artifacts list earlier than the video input.
+
+## Two unique features
+
+**U1 — Agent-shaped raw-materials output.** `VIDEO + FRAMES + TRANSCRIPT` in a single structured block (text today, JSON v1 next), designed for an LLM to read frames as images and transcript as text. No other CLI in this space composes the inputs in this shape.
+
+**U2 — Prompt library that maps `watch` output → concrete deliverables.** Five prompts in `prompts/` convert raw materials into working artifacts: project files, architecture diagram, React component, runnable notebook, step-by-step cheat sheet.
+
+Every user-facing artifact should reinforce U1, U2, or both. If it does neither, it's the wrong copy.
+
+## Tone rules
+
+- **Concrete over abstract.** *"Working React component"* beats *"powerful UI generation"*. Lead with outcomes the reader can touch.
+- **Verb–noun phrases.** *"Watch a video, get a diagram"* beats *"AI-powered video understanding for next-gen workflows"*.
+- **No hype words.** Banned: *revolutionary, powerful, magical, seamless, cutting-edge, AI-powered (about the tool itself), unleash, supercharge*.
+- **Honest cost framing.** Always pay-per-use. Never *"free"* without disclosing the credit ceiling.
+- **No emoji.** Except where they appear naturally in code or status output.
+- **No screenshots that age fast.** Show CLI output blocks (text) instead.
+
+## Pitch variants — good vs bad
+
+Good:
+
+- *"Watch any social video, get a working React component back."*
+- *"Hand a YouTube link to your agent. Get an architecture diagram of your own product back."*
+- *"A composable CLI that gives AI agents eyes and ears for any social video."*
+
+Bad:
+
+- *"The most powerful AI video understanding tool."* — hype + abstract
+- *"Revolutionary multimodal pipeline."* — banned words
+- *"watch-cli leverages cutting-edge AI to unlock video insights."* — filler verbs
+- *"Built on Kyma, the AI gateway."* — leads with our own infra; reader doesn't care
+
+## Where the locked pitch must appear
+
+Audit each time the README ships, the SKILL.md changes, or a new package goes out:
+
+- [ ] README first paragraph (above the install fold)
+- [ ] `SKILL.md` `description` frontmatter field
+- [ ] MCP server tool `description` field (once shipped)
+- [ ] npm package `description` field (once published)
+- [ ] Homebrew formula `desc` line (once shipped)
+- [ ] GitHub repo description (the field next to the repo name)
+- [ ] First line of any listing-submission PR body
+- [ ] First sentence of any blog or social post about the tool
+
+## Naming
+
+- **`watch-cli`** — the project. Always lowercase, hyphenated.
+- **`watch`** — the primary command. Lowercase.
+- Never *"WatchCLI"*, *"WatchCli"*, or *"Watch-CLI"* in prose. GitHub auto-capitalizes the title bar; that's cosmetic and out of our control, but never mirror it in writing.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,28 @@
 # watch-cli
 
-Give your AI agent eyes and ears for any social video.
+**Watch any social video → get an architecture diagram, working component, runnable notebook, or step-by-step cheat sheet — automatically.**
+
+Eyes and ears for your AI agent. watch-cli composes `yt-dlp` + `ffmpeg` + a Whisper-class ASR into a single command that hands an agent the raw materials to "watch" any video: VIDEO + FRAMES + TRANSCRIPT, ready for an LLM to read frames as images and transcript as text.
 
 ```bash
 watch https://twitter.com/anyone/status/12345
 ```
 
-You get back: a video file, evenly-spaced frames as JPGs, and the full
-audio transcript. Your agent reads them and "watches" the video — works
-on YouTube, X, LinkedIn, TikTok, Reddit, Vimeo, and Facebook. Login-walled
-posts (LinkedIn, X, FB) fall back to your browser cookies automatically.
+Works on YouTube, X, LinkedIn, TikTok, Reddit, Vimeo, and Facebook. Login-walled posts (LinkedIn, private X, FB) fall back to your browser cookies automatically.
+
+## What you can build
+
+Hand the `watch` output to your agent with one of five prompts in [`prompts/`](prompts/):
+
+| Drop in a video of… | Get back |
+|---|---|
+| A coding walkthrough | [Working project files](prompts/implement-from-video.md) |
+| A system architecture talk | [Interactive architecture diagram](prompts/extract-architecture.md) |
+| A UI / motion demo | [Working React component](prompts/clone-ux.md) |
+| A paper or research talk | [Runnable notebook](prompts/paper-to-code.md) |
+| A long tutorial | [Step-by-step cheat sheet](prompts/tutorial-walkthrough.md) |
+
+The prompt library is what turns *"video → frames + transcript"* into *"video → working artifact"*. The full [Prompt library](#prompt-library) section below has copy-paste templates.
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 0 of the defend-the-niche plan: lock the locked one-line pitch in every customer-facing surface so every later artifact (SKILL.md, MCP server, listings, HN post) references the same words.

### README — what changed

**Tagline** swapped from the generic *"Give your AI agent eyes and ears for any social video"* to the concrete locked pitch:

> **Watch any social video → get an architecture diagram, working component, runnable notebook, or step-by-step cheat sheet — automatically.**

The viral *"eyes and ears"* framing stays as a technical-bridge subtitle below the tagline.

**New section "What you can build"** above the install fold — frontloads U2 (the prompt library). Five rows, each linking to a real prompt file, each with a one-line outcome. A first-time visitor sees the value prop before scrolling past install.

### BRANDING.md — new

Contributor-facing style guide. Contents:

- Mission (1 sentence)
- Locked pitch (verbatim, with rules on how to vary it)
- U1 + U2 definitions
- Tone rules (concrete > abstract, verb–noun, banned hype words, no emoji, etc.)
- Pitch variants — good vs bad with concrete examples
- "Where the locked pitch must appear" checklist (8 surfaces)
- Naming conventions

This becomes the single source of truth anyone writing user-facing copy reads first. No strategic content — it's safe for public visibility.

### GitHub repo description

Updated via `gh repo edit` to match the locked pitch:

```
Watch any social video → get an architecture diagram, working component,
runnable notebook, or step-by-step cheat sheet — automatically.
```

Was previously still claiming *"~50x cheaper than calling a multimodal API on full video"* — a claim we already scrapped in PR #6 as ungrounded.

## What did NOT change

- Install instructions, command list, "Why pay-per-use" section, prompt library section, limitations — all untouched.
- No new dependencies, no behavior changes, no code edits.

## Test plan

- [ ] Render README on GitHub, confirm tagline + "What you can build" appear above the install fold
- [ ] Verify all 5 prompt links resolve (`prompts/implement-from-video.md`, etc.)
- [ ] BRANDING.md reads cleanly top-to-bottom
- [ ] Repo description on `github.com/sonpiaz/watch-cli` shows the new pitch