### PR TITLE
feat(phase-3): resilience — offline + health + pipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 node_modules/
 .DS_Store
 /tmp/
+.omc/
+tests/fixtures/

--- a/bin/audio-q
+++ b/bin/audio-q
@@ -14,7 +14,13 @@
 
 set -uo pipefail
 
+# Resolve symlinks so ROOT_DIR points at the real install dir, not ~/.local.
 SELF="${BASH_SOURCE[0]}"
+while [ -L "$SELF" ]; do
+  SELF_DIR="$(cd "$(dirname "$SELF")" && pwd)"
+  SELF="$(readlink "$SELF")"
+  [[ $SELF != /* ]] && SELF="$SELF_DIR/$SELF"
+done
 SELF_DIR="$(cd "$(dirname "$SELF")" && pwd)"
 ROOT_DIR="$(cd "$SELF_DIR/.." && pwd)"
 # shellcheck source=../lib/env.sh

--- a/bin/audio-q
+++ b/bin/audio-q
@@ -54,6 +54,20 @@ if [[ ! -f "$INPUT" ]]; then
   exit 64
 fi
 
+# Audio scene Q&A requires a multimodal LLM; no local open-source
+# equivalent ships at the quality bar today. If the user explicitly
+# requested local mode, fail loud — silently falling back to an API
+# call would ship audio over the wire without consent.
+if [[ "${_WATCH_AUDIO_MODE_RAW:-}" == "local" ]]; then
+  cat >&2 <<'ERR'
+[audio-q] error: audio-q has no local backend tag=audio-q-requires-api
+Audio scene Q&A requires a hosted model. Either:
+  - unset WATCH_AUDIO_MODE to use the configured API path, or
+  - export WATCH_AUDIO_MODE=kyma (or byok) for this call.
+ERR
+  exit 2
+fi
+
 if ! watch_cli_audio_mode_check "understand"; then
   echo "[audio-q] error: no usable audio backend tag=transcribe-other" >&2
   exit 4

--- a/bin/models
+++ b/bin/models
@@ -13,7 +13,13 @@
 
 set -uo pipefail
 
+# Resolve symlinks so ROOT_DIR points at the real install dir, not ~/.local.
 SELF="${BASH_SOURCE[0]}"
+while [ -L "$SELF" ]; do
+  SELF_DIR="$(cd "$(dirname "$SELF")" && pwd)"
+  SELF="$(readlink "$SELF")"
+  [[ $SELF != /* ]] && SELF="$SELF_DIR/$SELF"
+done
 SELF_DIR="$(cd "$(dirname "$SELF")" && pwd)"
 ROOT_DIR="$(cd "$SELF_DIR/.." && pwd)"
 # shellcheck source=../lib/env.sh

--- a/bin/transcribe
+++ b/bin/transcribe
@@ -3,23 +3,39 @@
 # Speech-to-text on any media file. Prints the transcript to stdout.
 # Auto-extracts audio from video and downsamples to mono 16kHz mp3 first.
 #
-# Routing:
-#   - Kyma mode (KYMA_API_KEY set): POST api.kymaapi.com/v1/audio/transcriptions
-#     One key opens every gate. Free credit at signup covers hundreds of videos.
-#     Get a Kyma key at https://kymaapi.com.
-#   - Direct mode (GROQ_API_KEY set): POST api.groq.com directly (BYO).
+# Routing (resolved at startup, single decision):
 #
-# Exit codes (see docs/exit-codes.md):
+#   WATCH_AUDIO_MODE       Result
+#   ───────────────────    ──────────────────────────────────────────
+#   local                  whisper.cpp on this machine — fully
+#                          offline, no audio leaves the device.
+#                          Requires whisper-cli (or main) on PATH and
+#                          ~/.watch-cli/models/ggml-large-v3-turbo.bin
+#                          (run install.sh --with-local).
+#   kyma                   POST api.kymaapi.com/v1/audio/transcriptions
+#                          One key opens every gate. Free credit at
+#                          signup covers hundreds of videos.
+#                          Get a Kyma key at https://kymaapi.com.
+#   byok                   POST api.groq.com directly (BYO).
+#   (unset)                Auto-detect: prefers local > kyma > byok.
+#                          Local wins when both binary and model are
+#                          present.
+#
+# An explicit WATCH_AUDIO_MODE is a contract — the script never falls
+# back to a different path. See docs/offline-mode.md for the full
+# routing table and exit-code semantics.
+#
+# Exit codes (see docs/exit-codes.md and docs/offline-mode.md):
 #   0 success · 1 general · 2 missing-dep · 4 transcribe fail · 64 usage error
 
 set -uo pipefail
 
-# Locate self → parent dir → lib/env.sh.
+# Locate self → parent dir → lib/{env,audio-routing,model-checksums}.sh.
 SELF="${BASH_SOURCE[0]}"
 SELF_DIR="$(cd "$(dirname "$SELF")" && pwd)"
 ROOT_DIR="$(cd "$SELF_DIR/.." && pwd)"
-# shellcheck source=../lib/env.sh
-source "$ROOT_DIR/lib/env.sh"
+# shellcheck source=../lib/audio-routing.sh
+source "$ROOT_DIR/lib/audio-routing.sh"
 
 INPUT=""
 LANG=""
@@ -27,7 +43,7 @@ LANG=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -h|--help)
-      sed -n '2,11p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,28p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     -V|--version)
@@ -50,25 +66,34 @@ if [[ -z "$INPUT" ]]; then
   exit 64
 fi
 
+# Resolve which backend to use up-front, before any audio is read.
+# Per docs/offline-mode.md the routing decision is made first so a
+# wrong WATCH_AUDIO_MODE surfaces missing-dep / missing-key before a
+# missing input file does.
+if ! watch_cli_resolve_audio_backend "transcribe"; then
+  exit "${WATCH_AUDIO_RESOLVE_EXIT:-2}"
+fi
+
 if [[ ! -f "$INPUT" ]]; then
   echo "[transcribe] error: file not found: $INPUT tag=usage-error" >&2
   exit 64
 fi
 
-if ! watch_cli_audio_mode_check "transcribe"; then
-  echo "[transcribe] error: no usable audio backend tag=transcribe-other" >&2
-  exit 4
-fi
-
-for dep in ffmpeg ffprobe curl; do
+for dep in ffmpeg ffprobe; do
   if ! command -v "$dep" >/dev/null 2>&1; then
     echo "[transcribe] error: $dep not found on PATH tag=missing-dep:$dep" >&2
     exit 2
   fi
 done
+# curl is only needed for API modes; skip when running fully local.
+if [[ "$WATCH_AUDIO_RESOLVED_MODE" != "local" ]] && ! command -v curl >/dev/null 2>&1; then
+  echo "[transcribe] error: curl not found on PATH tag=missing-dep:curl" >&2
+  exit 2
+fi
 
-# Always normalize to mono 16kHz mp3 — both Kyma and Groq accept it, and
-# this keeps payloads under 25MB even for ~30min sources.
+# Always normalize to mono 16kHz mp3 — the API backends accept it, and
+# this keeps payloads under 25MB even for ~30min sources. whisper.cpp
+# accepts mp3 in current builds too.
 HASH="$(echo -n "$INPUT" | shasum | cut -c1-10)"
 AUDIO="/tmp/transcribe_${HASH}.mp3"
 
@@ -80,17 +105,22 @@ if [[ ! -s "$AUDIO" ]]; then
   fi
 fi
 
-# POSIX size check: wc -c works on both macOS and Linux without a flag.
-SIZE="$(wc -c < "$AUDIO" | tr -d ' ')"
-if (( SIZE > 25 * 1024 * 1024 )); then
-  echo "[transcribe] error: audio is $((SIZE / 1024 / 1024))MB — exceeds 25MB cap. Trim source first. tag=transcribe-other" >&2
-  exit 4
+# Only the API paths have the 25MB upload cap; whisper.cpp reads from
+# disk so any size goes. Skip the check in local mode.
+if [[ "$WATCH_AUDIO_RESOLVED_MODE" != "local" ]]; then
+  # POSIX size check: wc -c works on both macOS and Linux without a flag.
+  SIZE="$(wc -c < "$AUDIO" | tr -d ' ')"
+  if (( SIZE > 25 * 1024 * 1024 )); then
+    echo "[transcribe] error: audio is $((SIZE / 1024 / 1024))MB — exceeds 25MB cap. Trim source first. tag=transcribe-other" >&2
+    exit 4
+  fi
 fi
 
 # Silence guard: ASR models hallucinate on silent input ("Thank you" is a
-# common Whisper failure mode). Skip the provider call entirely so we
+# common Whisper failure mode). Skip the inference call entirely so we
 # never return fabricated text. -60 dB is well below room noise; anything
-# below that is effectively digital silence.
+# below that is effectively digital silence. Applies to local and API
+# modes identically per docs/offline-mode.md.
 MAX_DB="$(ffmpeg -i "$AUDIO" -af volumedetect -f null /dev/null 2>&1 | \
           awk -F': ' '/max_volume/ { gsub(" dB", "", $2); print $2; exit }')"
 if [[ -n "$MAX_DB" ]]; then
@@ -101,7 +131,41 @@ if [[ -n "$MAX_DB" ]]; then
   fi
 fi
 
-case "$WATCH_AUDIO_MODE" in
+case "$WATCH_AUDIO_RESOLVED_MODE" in
+  local)
+    # whisper.cpp writes the transcript to <stem>.txt. Use a temp stem
+    # so concurrent invocations don't trample each other.
+    STEM="/tmp/transcribe_${HASH}_$$"
+    TXT="${STEM}.txt"
+    rm -f "$TXT"
+    # WATCH_DEBUG=1 routes whisper progress to stderr; otherwise swallow
+    # so the binary stays quiet on success.
+    if [[ -n "${WATCH_DEBUG:-}" ]]; then
+      WHISPER_STDERR="/dev/stderr"
+    else
+      WHISPER_STDERR="/dev/null"
+    fi
+    if ! "$WATCH_WHISPER_BIN" -m "$WATCH_WHISPER_MODEL" -f "$AUDIO" \
+        --output-txt -of "$STEM" >"$WHISPER_STDERR" 2>&1; then
+      rm -f "$TXT"
+      echo "[transcribe] error: whisper.cpp returned non-zero tag=transcribe-other" >&2
+      exit 4
+    fi
+    if [[ ! -s "$TXT" ]]; then
+      rm -f "$TXT"
+      echo "[transcribe] error: whisper.cpp returned empty transcript tag=transcribe-silent-audio" >&2
+      exit 4
+    fi
+    # Strip trailing newline and emit. Then clean up the txt file.
+    # printf with %s avoids re-adding a newline awk/cat would.
+    TEXT="$(cat "$TXT")"
+    rm -f "$TXT"
+    if [[ -z "$TEXT" ]]; then
+      echo "[transcribe] error: whisper.cpp returned empty transcript tag=transcribe-silent-audio" >&2
+      exit 4
+    fi
+    echo "$TEXT"
+    ;;
   kyma)
     # Use the "transcribe" alias rather than a concrete SKU. Lets Kyma swap
     # the underlying model (Whisper v4, Voxtral, …) without breaking watch-cli.
@@ -141,7 +205,7 @@ case "$WATCH_AUDIO_MODE" in
         exit 4 ;;
     esac
     ;;
-  direct|groq-only)
+  byok)
     ARGS=(
       -F "file=@$AUDIO"
       -F "model=whisper-large-v3-turbo"
@@ -156,7 +220,7 @@ case "$WATCH_AUDIO_MODE" in
       -H "User-Agent: $WATCH_CLI_USER_AGENT" \
       "${ARGS[@]}" \
       https://api.groq.com/openai/v1/audio/transcriptions 2>/dev/null)" || {
-      echo "[transcribe] error: Groq request failed tag=transcribe-other" >&2
+      echo "[transcribe] error: BYOK request failed tag=transcribe-other" >&2
       exit 4
     }
     HTTP_CODE="${BODY: -3}"
@@ -164,13 +228,13 @@ case "$WATCH_AUDIO_MODE" in
     case "$HTTP_CODE" in
       200) echo "$TEXT" ;;
       402|429)
-        echo "[transcribe] error: Groq quota or rate limit (HTTP $HTTP_CODE) tag=transcribe-quota" >&2
+        echo "[transcribe] error: BYOK quota or rate limit (HTTP $HTTP_CODE) tag=transcribe-quota" >&2
         exit 4 ;;
       408|504)
-        echo "[transcribe] error: Groq timeout (HTTP $HTTP_CODE) tag=transcribe-timeout" >&2
+        echo "[transcribe] error: BYOK timeout (HTTP $HTTP_CODE) tag=transcribe-timeout" >&2
         exit 4 ;;
       *)
-        echo "[transcribe] error: Groq returned HTTP $HTTP_CODE: $TEXT tag=transcribe-other" >&2
+        echo "[transcribe] error: BYOK returned HTTP $HTTP_CODE: $TEXT tag=transcribe-other" >&2
         exit 4 ;;
     esac
     ;;

--- a/bin/transcribe
+++ b/bin/transcribe
@@ -31,7 +31,13 @@
 set -uo pipefail
 
 # Locate self → parent dir → lib/{env,audio-routing,model-checksums}.sh.
+# Resolve symlinks so ROOT_DIR points at the real install dir, not ~/.local.
 SELF="${BASH_SOURCE[0]}"
+while [ -L "$SELF" ]; do
+  SELF_DIR="$(cd "$(dirname "$SELF")" && pwd)"
+  SELF="$(readlink "$SELF")"
+  [[ $SELF != /* ]] && SELF="$SELF_DIR/$SELF"
+done
 SELF_DIR="$(cd "$(dirname "$SELF")" && pwd)"
 ROOT_DIR="$(cd "$SELF_DIR/.." && pwd)"
 # shellcheck source=../lib/audio-routing.sh

--- a/bin/watch
+++ b/bin/watch
@@ -24,8 +24,8 @@
 # compact JSON object per URL to stdout (JSONL). Implies --format json
 # and suppresses text-format block markers. Errors per line keep
 # version:1 so consumers can detect the schema, and processing
-# continues to the next URL. Auto-enabled when stdin is not a TTY and
-# no URL argument is passed.
+# continues to the next URL. Pipe mode is opt-in via --pipe; running
+# `watch` with no args from a script context still exits 64 (usage).
 #
 # Exit codes: see docs/exit-codes.md.
 #   0 success · 1 general · 2 missing-dep · 3 download fail
@@ -88,16 +88,16 @@ while [[ $# -gt 0 ]]; do
 done
 
 SELF="${BASH_SOURCE[0]}"
+# Resolve symlinks so $ROOT_DIR points at the real install dir, not ~/.local.
+while [ -L "$SELF" ]; do
+  SELF_DIR="$(cd "$(dirname "$SELF")" && pwd)"
+  SELF="$(readlink "$SELF")"
+  [[ $SELF != /* ]] && SELF="$SELF_DIR/$SELF"
+done
 SELF_DIR="$(cd "$(dirname "$SELF")" && pwd)"
 ROOT_DIR="$(cd "$SELF_DIR/.." && pwd)"
 # shellcheck source=../lib/health.sh
 source "$ROOT_DIR/lib/health.sh"
-
-# Auto-enable pipe mode when stdin is not a TTY and no URL was passed.
-# This lets `cat urls.txt | watch` Just Work without an explicit flag.
-if [[ $PIPE -eq 0 && -z "$URL" ]] && [[ ! -t 0 ]]; then
-  PIPE=1
-fi
 
 # Pipe mode implies JSON output. A consumer reading JSONL doesn't want
 # text-block markers interleaved between objects.

--- a/bin/watch
+++ b/bin/watch
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# watch <url> [frame-count] [--cookies <file>] [--format text|json]
+# watch <url> [frame-count] [--cookies <file>] [--format text|json] [--pipe]
 # One-shot orchestrator: download a video, extract evenly-spaced frames,
 # transcribe the audio. Prints a single structured block easy for an AI
 # agent to consume.
@@ -20,6 +20,13 @@
 #   {"version":1,"video_path":"…","duration_sec":…,"frame_paths":[…],
 #    "transcript":"…"|null,"exit_code":…,"transcribe_cost_usd":…}
 #
+# Pipe mode (--pipe): reads URLs from stdin (one per line), emits one
+# compact JSON object per URL to stdout (JSONL). Implies --format json
+# and suppresses text-format block markers. Errors per line keep
+# version:1 so consumers can detect the schema, and processing
+# continues to the next URL. Auto-enabled when stdin is not a TTY and
+# no URL argument is passed.
+#
 # Exit codes: see docs/exit-codes.md.
 #   0 success · 1 general · 2 missing-dep · 3 download fail
 #   4 transcribe fail (partial: frames present, transcript=null)
@@ -37,6 +44,7 @@ URL=""
 COUNT="8"
 COOKIES_ARG=""
 FORMAT="text"
+PIPE=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -56,8 +64,12 @@ while [[ $# -gt 0 ]]; do
       FORMAT="${1#*=}"
       shift
       ;;
+    --pipe)
+      PIPE=1
+      shift
+      ;;
     -h|--help)
-      sed -n '2,31p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,38p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     -V|--version)
@@ -75,8 +87,26 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "$URL" ]]; then
-  echo "usage: watch <url> [frame-count] [--cookies <file>] [--format text|json] tag=usage-error" >&2
+SELF="${BASH_SOURCE[0]}"
+SELF_DIR="$(cd "$(dirname "$SELF")" && pwd)"
+ROOT_DIR="$(cd "$SELF_DIR/.." && pwd)"
+# shellcheck source=../lib/health.sh
+source "$ROOT_DIR/lib/health.sh"
+
+# Auto-enable pipe mode when stdin is not a TTY and no URL was passed.
+# This lets `cat urls.txt | watch` Just Work without an explicit flag.
+if [[ $PIPE -eq 0 && -z "$URL" ]] && [[ ! -t 0 ]]; then
+  PIPE=1
+fi
+
+# Pipe mode implies JSON output. A consumer reading JSONL doesn't want
+# text-block markers interleaved between objects.
+if [[ $PIPE -eq 1 ]]; then
+  FORMAT="json"
+fi
+
+if [[ $PIPE -eq 0 && -z "$URL" ]]; then
+  echo "usage: watch <url> [frame-count] [--cookies <file>] [--format text|json] [--pipe] tag=usage-error" >&2
   exit 64
 fi
 
@@ -84,9 +114,6 @@ if [[ "$FORMAT" != "text" && "$FORMAT" != "json" ]]; then
   echo "[watch] error: --format must be 'text' or 'json' (got '$FORMAT') tag=usage-error" >&2
   exit 64
 fi
-
-SELF="${BASH_SOURCE[0]}"
-SELF_DIR="$(cd "$(dirname "$SELF")" && pwd)"
 
 # Dependency check up-front so we exit 2, not 1, when a binary is missing.
 for dep in yt-dlp ffmpeg ffprobe jq curl python3; do
@@ -96,78 +123,149 @@ for dep in yt-dlp ffmpeg ffprobe jq curl python3; do
   fi
 done
 
-echo "[watch] downloading $URL …" >&2
-# shellcheck disable=SC2086
-VIDEO="$("$SELF_DIR/dl-video" "$URL" $COOKIES_ARG)"
-DL_RC=$?
-if [[ $DL_RC -ne 0 ]]; then
-  # dl-video already emitted a stderr line with tag=download-* and exited 3.
-  # Surface its exit code unchanged.
-  exit $DL_RC
-fi
-echo "[watch] video: $VIDEO" >&2
+# ── Per-URL pipeline ──────────────────────────────────────────────
+# Runs the download → frames → transcribe sequence for one URL.
+# Emits the documented block on stdout, returns the exit code.
+#
+# In pipe mode this is called once per stdin line; in single-URL mode
+# it runs exactly once.
+process_url() {
+  local url="$1"
+  local count="$2"
+  local format="$3"
+  local cookies_arg="$4"
+  local pipe_mode="$5"
 
-DUR="$(ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 "$VIDEO" 2>/dev/null || echo 0)"
-DUR_INT="${DUR%.*}"
-[[ -z "$DUR_INT" ]] && DUR_INT=0
+  # Pre-flight: upstream platform probe. Not a gate — just warns when
+  # yt-dlp's extractor for this domain looks broken today, so a doomed
+  # 30s download surfaces a hint up front.
+  check_platform_for_url "$url" || true
 
-echo "[watch] extracting $COUNT frames …" >&2
-FRAMES="$("$SELF_DIR/extract-frames" "$VIDEO" "$COUNT")"
-EF_RC=$?
-if [[ $EF_RC -ne 0 ]]; then
-  echo "[watch] error: extract-frames failed (rc=$EF_RC)" >&2
-  exit 1
-fi
-
-echo "[watch] transcribing audio …" >&2
-# Capture transcribe output and exit code separately. A non-zero exit
-# means partial success — emit the block with transcript=null and exit 4.
-TRANSCRIPT="$("$SELF_DIR/transcribe" "$VIDEO")"
-TR_RC=$?
-
-EXIT_CODE=0
-if [[ $TR_RC -ne 0 ]]; then
-  EXIT_CODE=4
-  TRANSCRIPT=""
-fi
-
-# ── Emit the contract block ──
-if [[ "$FORMAT" == "json" ]]; then
-  # Build frame_paths array from newline-separated FRAMES var.
-  # Filter out empty lines so a trailing newline doesn't yield [""].
-  FRAME_JSON="$(printf '%s\n' "$FRAMES" | jq -R . | jq -cs 'map(select(. != ""))')"
-
-  if [[ $TR_RC -ne 0 ]]; then
-    jq -cn \
-      --argjson frames "$FRAME_JSON" \
-      --arg video "$VIDEO" \
-      --argjson dur "$DUR_INT" \
-      --argjson rc "$EXIT_CODE" \
-      '{version:1, video_path:$video, duration_sec:$dur, frame_paths:$frames, transcript:null, exit_code:$rc}'
-  else
-    jq -cn \
-      --argjson frames "$FRAME_JSON" \
-      --arg video "$VIDEO" \
-      --argjson dur "$DUR_INT" \
-      --arg transcript "$TRANSCRIPT" \
-      --argjson rc "$EXIT_CODE" \
-      '{version:1, video_path:$video, duration_sec:$dur, frame_paths:$frames, transcript:$transcript, exit_code:$rc}'
+  echo "[watch] downloading $url …" >&2
+  local video dl_rc
+  # shellcheck disable=SC2086
+  video="$("$SELF_DIR/dl-video" "$url" $cookies_arg)"
+  dl_rc=$?
+  if [[ $dl_rc -ne 0 ]]; then
+    if [[ "$pipe_mode" -eq 1 ]]; then
+      _emit_pipe_error "$url" "$dl_rc" "download-failed"
+      return $dl_rc
+    fi
+    return $dl_rc
   fi
-else
-  echo "WATCH_OUTPUT_VERSION: 1"
-  echo "VIDEO: $VIDEO"
-  echo "DURATION: $DUR_INT"
-  echo "FRAMES:"
-  while IFS= read -r f; do
-    [[ -n "$f" ]] && echo "  $f"
-  done <<< "$FRAMES"
-  echo "TRANSCRIPT:"
-  if [[ $TR_RC -ne 0 ]]; then
-    echo "  null"
-  else
-    echo "$TRANSCRIPT" | sed 's/^/  /'
+  echo "[watch] video: $video" >&2
+
+  local dur dur_int
+  dur="$(ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 "$video" 2>/dev/null || echo 0)"
+  dur_int="${dur%.*}"
+  [[ -z "$dur_int" ]] && dur_int=0
+
+  echo "[watch] extracting $count frames …" >&2
+  local frames ef_rc
+  frames="$("$SELF_DIR/extract-frames" "$video" "$count")"
+  ef_rc=$?
+  if [[ $ef_rc -ne 0 ]]; then
+    echo "[watch] error: extract-frames failed (rc=$ef_rc)" >&2
+    if [[ "$pipe_mode" -eq 1 ]]; then
+      _emit_pipe_error "$url" 1 "extract-frames-failed"
+    fi
+    return 1
   fi
-  echo "EXIT: $EXIT_CODE"
+
+  echo "[watch] transcribing audio …" >&2
+  local transcript tr_rc
+  transcript="$("$SELF_DIR/transcribe" "$video")"
+  tr_rc=$?
+
+  local exit_code=0
+  if [[ $tr_rc -ne 0 ]]; then
+    exit_code=4
+    transcript=""
+  fi
+
+  # ── Emit the contract block ──
+  if [[ "$format" == "json" ]]; then
+    local frame_json
+    frame_json="$(printf '%s\n' "$frames" | jq -R . | jq -cs 'map(select(. != ""))')"
+
+    if [[ $tr_rc -ne 0 ]]; then
+      jq -cn \
+        --argjson frames "$frame_json" \
+        --arg video "$video" \
+        --argjson dur "$dur_int" \
+        --argjson rc "$exit_code" \
+        '{version:1, video_path:$video, duration_sec:$dur, frame_paths:$frames, transcript:null, exit_code:$rc}'
+    else
+      jq -cn \
+        --argjson frames "$frame_json" \
+        --arg video "$video" \
+        --argjson dur "$dur_int" \
+        --arg transcript "$transcript" \
+        --argjson rc "$exit_code" \
+        '{version:1, video_path:$video, duration_sec:$dur, frame_paths:$frames, transcript:$transcript, exit_code:$rc}'
+    fi
+  else
+    echo "WATCH_OUTPUT_VERSION: 1"
+    echo "VIDEO: $video"
+    echo "DURATION: $dur_int"
+    echo "FRAMES:"
+    while IFS= read -r f; do
+      [[ -n "$f" ]] && echo "  $f"
+    done <<< "$frames"
+    echo "TRANSCRIPT:"
+    if [[ $tr_rc -ne 0 ]]; then
+      echo "  null"
+    else
+      echo "$transcript" | sed 's/^/  /'
+    fi
+    echo "EXIT: $exit_code"
+  fi
+
+  return $exit_code
+}
+
+# Emit a v1-shaped error object on stdout for pipe mode. Keeps
+# `version: 1` so consumers can detect the schema and branch on
+# exit_code. Other fields are null.
+_emit_pipe_error() {
+  local url="$1"
+  local rc="$2"
+  local tag="$3"
+  jq -cn \
+    --arg url "$url" \
+    --argjson rc "$rc" \
+    --arg tag "$tag" \
+    '{version:1, url:$url, video_path:null, duration_sec:null, frame_paths:null, transcript:null, exit_code:$rc, error:$tag}'
+}
+
+# ── Pipe-mode loop ────────────────────────────────────────────────
+if [[ $PIPE -eq 1 ]]; then
+  # Track the worst-case exit code so the pipeline as a whole reports
+  # a non-zero exit when any URL failed. Successful runs return 0.
+  PIPE_WORST=0
+  while IFS= read -r LINE || [[ -n "$LINE" ]]; do
+    # Skip blank lines / comments.
+    LINE="${LINE%$'\r'}"
+    [[ -z "$LINE" ]] && continue
+    case "$LINE" in
+      \#*) continue ;;
+    esac
+    # Basic URL sanity check: must contain `://` and at least one
+    # alphanumeric char. Anything else surfaces as an error object
+    # but the loop continues.
+    if [[ ! "$LINE" =~ ^[a-zA-Z][a-zA-Z0-9+.-]*://[^[:space:]]+$ ]]; then
+      _emit_pipe_error "$LINE" 64 "invalid-url"
+      (( PIPE_WORST < 64 )) && PIPE_WORST=64
+      continue
+    fi
+    if ! process_url "$LINE" "$COUNT" "$FORMAT" "$COOKIES_ARG" 1; then
+      RC=$?
+      (( PIPE_WORST < RC )) && PIPE_WORST=$RC
+    fi
+  done
+  exit "$PIPE_WORST"
 fi
 
-exit $EXIT_CODE
+# ── Single-URL mode ───────────────────────────────────────────────
+process_url "$URL" "$COUNT" "$FORMAT" "$COOKIES_ARG" 0
+exit $?

--- a/docs/offline-mode.md
+++ b/docs/offline-mode.md
@@ -1,0 +1,350 @@
+# Offline mode (whisper.cpp)
+
+`bin/transcribe` shipped requiring a hosted-backend or BYOK key, so
+the tool could not run on an airplane, an air-gapped network, or
+anywhere the configured backend was unreachable. Phase 3 adds a
+third path: local whisper.cpp plus a pre-downloaded ggml model. With
+it installed, the transcribe step does no outbound HTTP — removing
+the structural dependency on any single backend, keeping the tool
+working when an upstream is throttled or down, and addressing the
+"marketing trojan" perception risk OSS reviewers flag when a CLI
+defaults to a hosted provider.
+
+This document is the contract for the local path. If `bin/transcribe`
+drifts, this spec wins.
+
+---
+
+## Routing priority
+
+`bin/transcribe` makes one routing decision at startup, before any
+audio is read. Driven by `WATCH_AUDIO_MODE` when set, by auto-detection
+when not.
+
+### When `WATCH_AUDIO_MODE` is set
+
+| Value | Action | Failure mode |
+|---|---|---|
+| `local` | Use whisper.cpp. Resolve binary, resolve model, run inference locally. | If no binary on `PATH`: exit `2`, stderr tag `missing-dep:whisper-cli`. If model file missing: exit `2`, stderr tag `missing-dep:whisper-model`. |
+| `kyma` | POST to Kyma `/v1/audio/transcriptions`. | If `KYMA_API_KEY` is unset: exit `2`, stderr tag `missing-key:KYMA_API_KEY`. |
+| `byok` | POST direct to BYOK provider audio endpoint. | If `GROQ_API_KEY` is unset: exit `2`, stderr tag `missing-key:GROQ_API_KEY`. |
+
+An explicit `WATCH_AUDIO_MODE` value is a contract. The script does
+not fall back to a different path when the requested one fails — if
+the user said `local`, falling back to an API call would silently
+violate that intent.
+
+### When `WATCH_AUDIO_MODE` is unset
+
+The script picks the first usable backend in this order:
+
+1. **Local whisper.cpp**, when both: a binary named `whisper-cli` (or
+   the older `main` — see *Binary detection*) is on `PATH`, **and**
+   the default model file exists at
+   `~/.watch-cli/models/ggml-large-v3-turbo.bin`.
+2. **Kyma**, when `KYMA_API_KEY` is set.
+3. **BYOK Groq**, when `GROQ_API_KEY` is set.
+4. **No backend**: exit `2`, stderr tag `missing-config`, message:
+
+   ```text
+   [transcribe] error: no usable audio backend tag=missing-config
+   Configure one of:
+     - export KYMA_API_KEY=…           (recommended — https://kymaapi.com)
+     - export GROQ_API_KEY=…           (BYOK direct)
+     - install whisper.cpp + model     (fully offline — see docs/offline-mode.md)
+   ```
+
+Local is preferred over a configured API key when both exist: it costs
+nothing per call, leaks no audio to a third party, and keeps working
+without a network. Users who prefer the API path on a machine that has
+both can force it with `WATCH_AUDIO_MODE=kyma`.
+
+---
+
+## whisper.cpp binary detection
+
+watch-cli probes two binary names, in order: `whisper-cli` (current
+upstream name; shipped by the Homebrew bottle and any whisper.cpp
+build from roughly mid-2024 onward), then `main` (legacy name from
+older builds, kept as a fallback so existing installs do not break).
+Resolution is `command -v whisper-cli` first, `command -v main`
+second. First hit wins; the resolved path is captured locally so
+debug logs record which binary was used.
+
+Install paths the implementer should be ready for:
+
+- **Homebrew (macOS):** package `whisper-cpp` (with hyphen), binary
+  `whisper-cli`. Bottle does not include a model.
+- **Build from source (Linux / any):** upstream uses CMake —
+  `git clone https://github.com/ggml-org/whisper.cpp ~/.watch-cli/whisper.cpp && cd ~/.watch-cli/whisper.cpp && cmake -B build && cmake --build build -j --config Release`.
+  Binary at `~/.watch-cli/whisper.cpp/build/bin/whisper-cli`;
+  `install.sh --with-local` (below) symlinks into
+  `~/.local/bin/whisper-cli`.
+
+---
+
+## Model lifecycle
+
+**Default model:** `ggml-large-v3-turbo` — multilingual, ~1.62 GB on
+disk, fastest of the large-v3 family on Apple Silicon. Comparable
+quality to the hosted `transcribe` alias.
+
+**Storage path:** `~/.watch-cli/models/ggml-large-v3-turbo.bin`,
+overridable via `WATCH_MODELS_DIR`. Multiple models in the same
+directory are allowed; only the active model's file is read.
+
+**How the model gets there — two opt-in paths:**
+
+1. **At install time:** `install.sh --with-local` prints expected
+   disk footprint, asks `Y/n`, downloads on confirmation.
+2. **At first use:** if `WATCH_AUDIO_MODE=local` is set and the model
+   file is missing, the script prompts:
+
+   ```text
+   [transcribe] local mode requested but no model found at
+     ~/.watch-cli/models/ggml-large-v3-turbo.bin
+   Download ggml-large-v3-turbo (~1.62 GB)? [y/N]
+   ```
+
+   Only explicit `y` proceeds. Anything else (default `N`, blank,
+   `n`, EOF) → exit `2`, tag `missing-dep:whisper-model`. No silent
+   network activity ever happens in local mode.
+
+**Download URL:**
+
+```text
+https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin
+```
+
+Verified as a 302 redirect to a signed HuggingFace CDN URL,
+content-length `1624555275` bytes (≈ 1.62 GB), content-type
+`application/octet-stream`. Follow redirects (`curl -fL`); report
+progress on stderr.
+
+**Integrity verification:** the script computes SHA256 and compares
+against a hash pinned in `lib/model-checksums.sh` (one entry per
+known model). Upstream publishes SHA1 only
+(`4af2b29d7ec73d781377bfd1758ca957a807e941` for `large-v3-turbo`);
+re-hash with SHA256 once at implementation time and pin it in-tree —
+SHA256 is what every other watch-cli artifact uses and what
+`shasum -a 256` defaults to on macOS.
+
+Mismatch → exit `1`, tag `model-checksum-mismatch`, message with
+expected/actual hashes and instructions to delete the partial file
+and retry. The partial file is **not** auto-deleted; surfacing the
+path lets the user inspect before losing it.
+
+---
+
+## Disk-space check
+
+Before any model download, the script calls `df -P` on the target
+directory and requires ≥ **2 GB free**. The model is 1.62 GB; a
+strict 1.62 GB check fails on filesystems with metadata overhead.
+
+Insufficient → exit `1`, tag `insufficient-disk`, message:
+
+```text
+[transcribe] error: insufficient disk space tag=insufficient-disk
+  required: 2 GB at ~/.watch-cli/models/
+  available: 0.4 GB
+Free at least 2 GB or set WATCH_MODELS_DIR to a different mount.
+```
+
+---
+
+## Invocation contract
+
+In local mode, `bin/transcribe` runs exactly this command (`$BIN` =
+`whisper-cli` or `main` per detection):
+
+```bash
+"$BIN" -m "$WATCH_MODELS_DIR/ggml-large-v3-turbo.bin" \
+       -f "$AUDIO" --output-txt -of "$STEM"
+```
+
+- `-m` is the absolute model path.
+- `-f` is the pre-normalized audio file from the existing ffmpeg step
+  (mono 16 kHz). whisper.cpp accepts WAV and MP3 in current builds;
+  keep WAV default to avoid the 16-bit-WAV-only constraint some older
+  `main` builds still enforce.
+- `--output-txt -of <stem>` writes the transcript to `<stem>.txt`.
+  Script reads it, strips trailing newline, prints to stdout, unlinks.
+
+whisper.cpp progress goes to stderr and is swallowed (redirected to
+`/dev/null`, or to a debug log when `WATCH_DEBUG=1`).
+
+### Silent-audio handling
+
+An empty transcript from whisper.cpp is treated identically to an
+empty transcript from any API backend: exit `4`, tag
+`transcribe-silent-audio`. Text renders `null` in the `TRANSCRIPT:`
+block; JSON sets `transcript` to `null`. The existing pre-flight
+silence check (`ffmpeg -af volumedetect` ≥ −60 dB) runs **before**
+the whisper.cpp invocation, so digitally silent input short-circuits
+without spawning whisper.cpp.
+
+---
+
+## Cost field in v1 JSON output
+
+The v1 schema declares `transcribe_cost_usd` as **optional**: absent
+when the backend reports no cost. Local mode is exactly that case —
+no per-call cost, and emitting `0` would collide with "the backend
+told us this call was free". So in local mode the script **omits**
+`transcribe_cost_usd` from the JSON object entirely. The key is
+present in Kyma mode (real number returned), absent in local and in
+BYOK Groq mode (no cost metadata).
+
+Consumers MUST check key presence explicitly. From
+[`output-schema.md`](output-schema.md): *"A `0` cost is meaningful
+(cached transcript, free tier); an absent cost is 'the backend did
+not tell us'."* Same rule applies in local mode.
+
+---
+
+## `audio-q` is API-only
+
+`audio-q` reasons over the audio scene — tone, music, sound effects,
+language, emotion — via a multimodal LLM. There is no local
+open-source equivalent at the quality bar shipped today, so watch-cli
+does not pretend to support offline `audio-q`.
+
+When `WATCH_AUDIO_MODE=local` is set and any caller invokes
+`audio-q`, the script fails with exit `2`, tag `audio-q-requires-api`:
+
+```text
+[audio-q] error: audio-q has no local backend tag=audio-q-requires-api
+Audio scene Q&A requires a hosted model. Either:
+  - unset WATCH_AUDIO_MODE to use the configured API path, or
+  - export WATCH_AUDIO_MODE=kyma (or byok) for this call.
+```
+
+No silent fallback.
+
+---
+
+## Fallback policy
+
+When local mode fails — model missing, binary missing, audio
+unreadable, transcript empty, checksum mismatch — `bin/transcribe`
+exits with the matching code from the table below. It does **not**
+silently fall back to an API call. A user who chose local chose it
+for privacy, cost, or network independence; silent fallback would
+ship audio over the wire without consent. Users who want "prefer
+local, fall back to API" can wrap `transcribe` and branch on the
+exit code themselves — local-mode tags are distinct enough.
+
+### Local-mode exit-code / tag table
+
+| Condition | Exit | Stderr tag |
+|---|---|---|
+| Binary not on `PATH` | `2` | `missing-dep:whisper-cli` |
+| Model file missing | `2` | `missing-dep:whisper-model` |
+| User declined first-run download prompt | `2` | `missing-dep:whisper-model` |
+| Insufficient disk before download | `1` | `insufficient-disk` |
+| Downloaded model fails SHA256 check | `1` | `model-checksum-mismatch` |
+| whisper.cpp returned non-zero | `4` | `transcribe-other` |
+| whisper.cpp returned empty transcript | `4` | `transcribe-silent-audio` |
+
+All tags are appended to the contract in [`exit-codes.md`](exit-codes.md)
+under the same append-only rules as v1.
+
+---
+
+## `install.sh --with-local`
+
+A new installer flag that bootstraps the local path end-to-end:
+
+1. **Detect host OS.**
+2. **macOS:** if `whisper-cli` missing, print
+   `brew install whisper-cpp` (package `whisper-cpp`, binary
+   `whisper-cli`) and prompt before running. Do not run brew
+   automatically — brew installs touch the global environment.
+3. **Debian / Ubuntu / generic Linux:** if `whisper-cli` missing,
+   build from source into `~/.watch-cli/whisper.cpp/`
+   (`git clone … && cmake -B build && cmake --build build -j --config Release`),
+   then symlink `…/build/bin/whisper-cli` →
+   `~/.local/bin/whisper-cli`. Requires `cmake` and a C++ toolchain;
+   print an `apt install` hint and exit if either is missing.
+4. **Disk-space check** — ≥ 2 GB free at `~/.watch-cli/models/` or
+   abort with `insufficient-disk`.
+5. **Download default model** with progress to stderr.
+6. **SHA256-verify** against pinned hash; mismatch aborts.
+7. **Print confirmation:**
+
+   ```text
+   ✓ whisper-cli installed at /usr/local/bin/whisper-cli
+   ✓ model installed at ~/.watch-cli/models/ggml-large-v3-turbo.bin (1.62 GB)
+   ✓ ~/.watch-cli/ now uses 1.7 GB of disk
+
+   Try it offline:
+     export WATCH_AUDIO_MODE=local
+     watch https://www.youtube.com/watch?v=dQw4w9WgXcQ
+   ```
+
+`--with-local` is independent of `--with-skill` and `--with-mcp`;
+combine or use any subset.
+
+---
+
+## Test plan
+
+The implementer must verify, on a clean macOS or Ubuntu host:
+
+1. **No binary, mode forced.** `WATCH_AUDIO_MODE=local`, no
+   `whisper-cli` on `PATH` → exit `2`, stderr contains
+   `tag=missing-dep:whisper-cli`. No download attempted.
+2. **No model, mode forced, prompt declined.** Binary present, model
+   absent, prompt declined → exit `2`, tag
+   `missing-dep:whisper-model`. No file written under
+   `~/.watch-cli/models/`.
+3. **Happy path.** Binary + model + speech input → exit `0`, stdout
+   contains the transcript. `watch --format json` omits
+   `transcribe_cost_usd` (`jq 'has("transcribe_cost_usd")'` → `false`).
+4. **Silent audio.** Local mode, silent input → exit `4`, tag
+   `transcribe-silent-audio`, JSON `transcript` is `null`.
+5. **Checksum mismatch.** Corrupt the model, rerun with mode forced
+   → exit `1`, tag `model-checksum-mismatch`. No fallback to API
+   even with `KYMA_API_KEY` set.
+6. **`audio-q` blocked.** `WATCH_AUDIO_MODE=local`, `audio-q` on any
+   input → exit `2`, tag `audio-q-requires-api`.
+7. **No regression.** `tests/test-output-schema.sh` still passes with
+   `WATCH_AUDIO_MODE` unset.
+
+All seven are deterministic and scriptable; add to
+`tests/test-offline-mode.sh` in the same PR.
+
+---
+
+## Anti-patterns
+
+- **Do not commit the model binary to git.** 1.62 GB would break
+  clone times, hosting limits, and CI caches. Model lives on
+  HuggingFace, fetched on demand.
+- **Do not auto-download models on first run without consent.** User
+  must see the size and answer `y`. A 1.62 GB silent download on a
+  tethered connection is an unforgivable surprise.
+- **Do not silently fall back from local to any API path.** A user
+  who chose local chose it for privacy, cost, or network
+  independence. Falling back voids the choice.
+- **Do not bundle whisper.cpp source.** Own release cadence and
+  license. `install.sh --with-local` clones upstream into
+  `~/.watch-cli/whisper.cpp/`; not a submodule.
+- **Do not name competing hosted backends.** Per `BRANDING.md`,
+  comparisons stay generic. Describe local mode as "fully offline"
+  or "no API key required", not by contrast to a specific provider.
+
+---
+
+## Cross-references
+
+- Exit-code semantics and tag conventions: [`exit-codes.md`](exit-codes.md).
+  Eight new tags ship under the append-only v1 promise:
+  `missing-dep:whisper-cli`, `missing-dep:whisper-model`,
+  `missing-key:KYMA_API_KEY`, `missing-key:GROQ_API_KEY`,
+  `missing-config`, `audio-q-requires-api`,
+  `model-checksum-mismatch`, `insufficient-disk`.
+- JSON / text shape + `transcribe_cost_usd` omission:
+  [`output-schema.md`](output-schema.md).
+- User-facing copy rules: [`../BRANDING.md`](../BRANDING.md).

--- a/docs/output-schema.md
+++ b/docs/output-schema.md
@@ -286,10 +286,10 @@ parsing fragile details guarantees breakage on the next release.
 ## Pipe mode (JSONL)
 
 `watch --pipe` accepts one URL per line on stdin and emits one
-compact JSON object per URL on stdout — a JSONL stream. The mode is
-auto-enabled when stdin is not a TTY *and* no URL argument was
-passed, so `cat urls.txt | watch` Just Works without the explicit
-flag.
+compact JSON object per URL on stdout — a JSONL stream. Pipe mode is
+opt-in via the `--pipe` flag — running `watch` with no args (even
+with piped stdin) still exits with code 64 (usage error). Use
+`cat urls.txt | watch --pipe` to drive a batch.
 
 The pipe-mode emission rules:
 

--- a/docs/output-schema.md
+++ b/docs/output-schema.md
@@ -283,6 +283,56 @@ parsing fragile details guarantees breakage on the next release.
 
 ---
 
+## Pipe mode (JSONL)
+
+`watch --pipe` accepts one URL per line on stdin and emits one
+compact JSON object per URL on stdout — a JSONL stream. The mode is
+auto-enabled when stdin is not a TTY *and* no URL argument was
+passed, so `cat urls.txt | watch` Just Works without the explicit
+flag.
+
+The pipe-mode emission rules:
+
+- One stdout line per stdin URL, in input order.
+- Each line is the same v1 JSON object documented above when the run
+  succeeds (or partially succeeds — exit 4 with `transcript:null`).
+- On a per-URL failure that prevented JSON emission (download error,
+  invalid URL, extract-frames crash) the line is an **error object**:
+
+  ```json
+  {"version":1,"url":"<input>","video_path":null,"duration_sec":null,
+   "frame_paths":null,"transcript":null,"exit_code":<rc>,"error":"<tag>"}
+  ```
+
+  Error objects keep `version: 1` so a consumer reading JSONL can
+  always detect the schema, and `exit_code` carries the documented
+  code from [`exit-codes.md`](exit-codes.md) (`3` download, `64`
+  invalid URL, etc.). The `error` field carries a short tag.
+
+- Blank lines and `#`-prefixed comment lines on stdin are skipped
+  silently.
+
+- Per-URL failures do **not** abort the pipe. The loop keeps reading
+  and the worst exit code across all URLs is the process exit. A
+  consumer that only cares whether *any* URL succeeded can branch on
+  per-line `exit_code` instead of the process exit.
+
+Pipe mode implies `--format json`. The text-format block markers
+(`WATCH_OUTPUT_VERSION:`, `VIDEO:`, …) are not emitted in pipe mode
+because they would interleave between JSONL records and break the
+"one line per record" contract.
+
+A minimal consumer:
+
+```bash
+cat urls.txt | watch --pipe | jq -c 'select(.exit_code == 0) | .transcript'
+```
+
+See [`../examples/batch-watch.sh`](../examples/batch-watch.sh) for a
+fuller example that writes `results.jsonl` to disk.
+
+---
+
 ## Cross-references
 
 - Exit code semantics, stderr tag conventions, partial-success rule

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -41,3 +41,28 @@ ships fast (often weekly) for new platform changes.
 There's nothing to add. Any URL `yt-dlp` supports works in `watch-cli`
 out of the box. The full list of 1,800+ supported sites lives at
 [yt-dlp/supportedsites.md](https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md).
+
+## Breakage and recovery
+
+`watch-cli` is a thin wrapper around `yt-dlp`. If a platform stops
+working — a YouTube URL that downloaded yesterday returns 403 today,
+or a TikTok URL hangs forever — the breakage is almost always a
+`yt-dlp` extractor that the upstream platform has changed under.
+
+Recovery is two steps:
+
+1. **`yt-dlp -U`** — pulls the latest extractor patch. The project
+   ships fast (often weekly) for platform changes. Most reported
+   breakages are fixed within 24–72 hours of someone filing the issue.
+2. **Check the issue tracker.** If `-U` didn't help, the breakage may
+   be in flight: search
+   [github.com/yt-dlp/yt-dlp/issues](https://github.com/yt-dlp/yt-dlp/issues)
+   for the platform tag (`[youtube]`, `[tiktok]`, `[linkedin]`, …).
+   An existing open issue means the fix is being worked; subscribe and
+   wait. No issue means file one.
+
+`watch-cli` runs a lightweight upstream probe before each download (a
+`yt-dlp --simulate` against a known-stable canary URL per platform,
+result cached 24h). On probe failure it emits a stderr warning
+`tag=platform-probe-fail` and proceeds anyway — a stale canary URL is
+also a possible cause, and the actual target URL may still work.

--- a/examples/batch-watch.sh
+++ b/examples/batch-watch.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# examples/batch-watch.sh
+# Read URLs from a file, watch each, write a JSONL artifact log to an
+# output directory. Demonstrates `watch --pipe` slotting into a shell
+# pipeline.
+#
+# Usage:
+#   examples/batch-watch.sh urls.txt [out-dir]
+#
+# Output:
+#   <out-dir>/results.jsonl — one JSON object per input URL (success
+#                              or error, both keep version:1 so a
+#                              consumer can branch on exit_code).
+#
+# Per-URL failures don't abort the loop; the pipeline keeps going and
+# the failing object lands in results.jsonl with `exit_code` ≠ 0 and
+# an `error` tag. See docs/output-schema.md for the pipe-mode shape.
+
+set -uo pipefail
+
+urls_file="${1:-}"
+out_dir="${2:-./watched}"
+
+if [[ -z "$urls_file" || ! -f "$urls_file" ]]; then
+  echo "usage: batch-watch.sh <urls-file> [out-dir]" >&2
+  exit 64
+fi
+
+mkdir -p "$out_dir"
+cat "$urls_file" | watch --pipe | jq -c '.' > "$out_dir/results.jsonl"
+
+echo "watched $(wc -l < "$out_dir/results.jsonl" | tr -d ' ') URLs → $out_dir/results.jsonl"

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,10 @@
 #                  so Claude Code picks up the watch-cli skill on next start.
 #   --with-mcp     Print the manual install hint for the MCP stdio server
 #                  (@sonpiaz/watch-cli-mcp on npm — not auto-installed yet).
+#   --with-local   Bootstrap the offline transcribe path: install
+#                  whisper.cpp (binary `whisper-cli`) and download the
+#                  default ggml model (~1.62 GB, SHA256-verified) into
+#                  ~/.watch-cli/models/. See docs/offline-mode.md.
 #   --help, -h     Show this help and exit.
 
 set -euo pipefail
@@ -21,6 +25,7 @@ CLAUDE_SKILLS_DIR="${HOME}/.claude/skills"
 
 WITH_SKILL=0
 WITH_MCP=0
+WITH_LOCAL=0
 
 red() { printf "\033[31m%s\033[0m\n" "$*"; }
 green() { printf "\033[32m%s\033[0m\n" "$*"; }
@@ -33,13 +38,16 @@ watch-cli installer
 
 Usage:
   curl -fsSL https://raw.githubusercontent.com/sonpiaz/watch-cli/main/install.sh | bash
-  ./install.sh [--with-skill] [--with-mcp]
+  ./install.sh [--with-skill] [--with-mcp] [--with-local]
 
 Flags:
   --with-skill   After install, copy SKILL.md into ~/.claude/skills/watch-cli/
                  so Claude Code picks up the watch-cli skill on next start.
   --with-mcp     Print the manual install hint for the MCP stdio server
                  (@sonpiaz/watch-cli-mcp on npm — not auto-installed yet).
+  --with-local   Bootstrap the offline transcribe path: install whisper.cpp
+                 (binary `whisper-cli`) and download the default ggml model
+                 (~1.62 GB, SHA256-verified) into ~/.watch-cli/models/.
   -h, --help     Show this help and exit.
 EOF
 }
@@ -49,6 +57,7 @@ while (($# > 0)); do
   case "$1" in
     --with-skill) WITH_SKILL=1; shift ;;
     --with-mcp) WITH_MCP=1; shift ;;
+    --with-local) WITH_LOCAL=1; shift ;;
     -h|--help) usage; exit 0 ;;
     *) red "Unknown flag: $1"; echo; usage; exit 64 ;;
   esac
@@ -122,6 +131,153 @@ if (( WITH_MCP )); then
   yellow "MCP server install will be available once @sonpiaz/watch-cli-mcp is published to npm — install manually for now:"
   echo "    npm install -g @sonpiaz/watch-cli-mcp"
   echo
+fi
+
+# ── Optional: offline transcribe path (whisper.cpp + default model) ──
+if (( WITH_LOCAL )); then
+  echo
+  yellow "Setting up offline transcribe path (whisper.cpp + default model)…"
+
+  # Source the pinned checksums so we use a single value across the
+  # installer and the routing library.
+  # shellcheck source=lib/model-checksums.sh
+  source "$INSTALL_DIR/lib/model-checksums.sh"
+
+  MODEL_DIR="$INSTALL_DIR/models"
+  # Honor a custom WATCH_MODELS_DIR if the caller pre-set it.
+  MODEL_DIR="${WATCH_MODELS_DIR:-$MODEL_DIR}"
+  MODEL_FILE="$MODEL_DIR/$WATCH_MODEL_FILE_LARGE_V3_TURBO"
+  MODEL_URL="$WATCH_MODEL_URL_LARGE_V3_TURBO"
+  MODEL_SHA256="$WATCH_MODEL_SHA256_LARGE_V3_TURBO"
+
+  OS_NAME="$(uname -s)"
+
+  # 1. Resolve binary. Both `whisper-cli` (current upstream name) and
+  # the legacy `main` are accepted.
+  WHISPER_BIN=""
+  for name in whisper-cli main; do
+    if command -v "$name" >/dev/null 2>&1; then
+      WHISPER_BIN="$(command -v "$name")"
+      break
+    fi
+  done
+
+  if [[ -z "$WHISPER_BIN" ]]; then
+    case "$OS_NAME" in
+      Darwin)
+        # brew installs touch the global environment — confirm
+        # before running.
+        if ! command -v brew >/dev/null 2>&1; then
+          red "Homebrew required to install whisper-cpp on macOS, but 'brew' is not on PATH."
+          echo "Install Homebrew (https://brew.sh) and re-run ./install.sh --with-local."
+          exit 1
+        fi
+        echo
+        echo "whisper-cli not found. About to run:"
+        echo "    brew install whisper-cpp"
+        printf "Proceed? [Y/n] "
+        read -r ans
+        case "$ans" in
+          n|N|no|NO)
+            yellow "Skipped whisper-cpp install. Run 'brew install whisper-cpp' manually and re-run."
+            exit 1
+            ;;
+        esac
+        brew install whisper-cpp
+        WHISPER_BIN="$(command -v whisper-cli)"
+        ;;
+      Linux)
+        # Debian / Ubuntu / any Linux: clone + build from source.
+        if [[ -f /etc/os-release ]]; then
+          # shellcheck disable=SC1091
+          source /etc/os-release
+        fi
+        if ! command -v cmake >/dev/null 2>&1; then
+          red "cmake required to build whisper.cpp on Linux, but 'cmake' is not on PATH."
+          echo "Install: sudo apt install build-essential cmake git"
+          exit 1
+        fi
+        SRC_DIR="$INSTALL_DIR/whisper.cpp"
+        if [[ ! -d "$SRC_DIR/.git" ]]; then
+          yellow "Cloning whisper.cpp to $SRC_DIR…"
+          git clone --quiet --depth=1 https://github.com/ggml-org/whisper.cpp "$SRC_DIR"
+        else
+          yellow "Updating existing whisper.cpp clone…"
+          git -C "$SRC_DIR" pull --rebase --quiet || true
+        fi
+        yellow "Building whisper.cpp (this takes 1–3 min)…"
+        (cd "$SRC_DIR" && cmake -B build >/dev/null && cmake --build build -j --config Release >/dev/null)
+        if [[ ! -x "$SRC_DIR/build/bin/whisper-cli" ]]; then
+          red "Build completed but whisper-cli binary not at $SRC_DIR/build/bin/whisper-cli."
+          exit 1
+        fi
+        mkdir -p "$BIN_LINK_DIR"
+        ln -sf "$SRC_DIR/build/bin/whisper-cli" "$BIN_LINK_DIR/whisper-cli"
+        WHISPER_BIN="$BIN_LINK_DIR/whisper-cli"
+        ;;
+      *)
+        red "--with-local: unsupported OS ($OS_NAME). Build whisper.cpp manually and put 'whisper-cli' on PATH."
+        exit 1
+        ;;
+    esac
+  fi
+  green "✓ whisper-cli installed at $WHISPER_BIN"
+
+  # 2. Disk-space check before downloading. The spec requires ≥ 2 GB
+  # free at the model dir; df -P is POSIX so it works on macOS and
+  # Linux without flag drift.
+  mkdir -p "$MODEL_DIR"
+  AVAIL_KB="$(df -P "$MODEL_DIR" | tail -1 | awk '{print $4}')"
+  # 2 GB = 2*1024*1024 KB = 2097152 KB.
+  if (( AVAIL_KB < 2097152 )); then
+    AVAIL_GB="$(awk -v k="$AVAIL_KB" 'BEGIN { printf "%.1f", k/1024/1024 }')"
+    red "[--with-local] error: insufficient disk space tag=insufficient-disk"
+    echo "  required: 2 GB at $MODEL_DIR"
+    echo "  available: ${AVAIL_GB} GB"
+    echo "Free at least 2 GB or set WATCH_MODELS_DIR to a different mount."
+    exit 1
+  fi
+
+  # 3. Download the model with progress on stderr. Skip if already
+  # present and matching the pinned checksum.
+  if [[ -s "$MODEL_FILE" ]]; then
+    yellow "Model already present at $MODEL_FILE — verifying checksum…"
+  else
+    yellow "Downloading $WATCH_MODEL_FILE_LARGE_V3_TURBO (~1.62 GB) from HuggingFace…"
+    if ! curl --progress-bar -fL "$MODEL_URL" -o "$MODEL_FILE.partial"; then
+      red "Download failed."
+      rm -f "$MODEL_FILE.partial"
+      exit 1
+    fi
+    mv "$MODEL_FILE.partial" "$MODEL_FILE"
+  fi
+
+  # 4. SHA256-verify against the pinned hash. Mismatch deletes the
+  # file so a second `--with-local` run gets a clean download.
+  yellow "Verifying SHA256…"
+  ACTUAL_SHA="$(shasum -a 256 "$MODEL_FILE" | awk '{print $1}')"
+  if [[ "$ACTUAL_SHA" != "$MODEL_SHA256" ]]; then
+    red "[--with-local] error: model-checksum-mismatch"
+    echo "  expected: $MODEL_SHA256"
+    echo "  actual:   $ACTUAL_SHA"
+    echo "  path:     $MODEL_FILE"
+    echo "Deleting the bad file. Re-run ./install.sh --with-local to retry."
+    rm -f "$MODEL_FILE"
+    exit 1
+  fi
+  green "✓ model installed at $MODEL_FILE (1.62 GB)"
+
+  # 5. Final confirmation with disk usage of the install dir.
+  USAGE="$(du -sh "$INSTALL_DIR" 2>/dev/null | awk '{print $1}' || echo "?")"
+  green "✓ $INSTALL_DIR now uses $USAGE of disk"
+  echo
+  echo "Try it offline:"
+  echo "    export WATCH_AUDIO_MODE=local"
+  echo "    watch https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+  # TODO(phase-3+): first-run prompt in bin/transcribe to offer the
+  # download when the user sets WATCH_AUDIO_MODE=local with no model
+  # on disk. Spec'd in docs/offline-mode.md "Model lifecycle" §2.
 fi
 
 # ── Env file scaffold ──

--- a/lib/audio-routing.sh
+++ b/lib/audio-routing.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Audio backend routing for watch-cli.
+#
+# Resolves which transcribe path runs at script startup, before any
+# audio is read. Driven by WATCH_AUDIO_MODE when explicitly set; falls
+# back to auto-detection when unset. See docs/offline-mode.md for the
+# full priority table.
+#
+# Exports on success:
+#   WATCH_AUDIO_RESOLVED_MODE  — one of: local, kyma, byok
+#   WATCH_WHISPER_BIN          — absolute path to whisper-cli or main
+#                                (local mode only)
+#   WATCH_WHISPER_MODEL        — absolute path to the ggml model file
+#                                (local mode only)
+#   WATCH_MODELS_DIR           — defaults to ~/.watch-cli/models when
+#                                unset
+#
+# On failure: emits a tagged stderr line and returns non-zero with the
+# expected exit code in WATCH_AUDIO_RESOLVE_EXIT so the caller can
+# `exit "$WATCH_AUDIO_RESOLVE_EXIT"`.
+#
+# An explicit WATCH_AUDIO_MODE value is a contract: the resolver does
+# not silently fall through to a different backend when the requested
+# one fails. A user who said `local` chose it for privacy, cost, or
+# network independence — silently routing audio over an API would void
+# that intent.
+
+[[ -n "${WATCH_CLI_AUDIO_ROUTING_LOADED:-}" ]] && return 0
+export WATCH_CLI_AUDIO_ROUTING_LOADED=1
+
+# Pull in env defaults (KYMA_API_KEY, GROQ_API_KEY) without redefining.
+# env.sh is idempotent so double-source is safe.
+_AR_SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./env.sh
+source "$_AR_SELF_DIR/env.sh"
+# shellcheck source=./model-checksums.sh
+source "$_AR_SELF_DIR/model-checksums.sh"
+
+# Default model dir, overridable via WATCH_MODELS_DIR.
+export WATCH_MODELS_DIR="${WATCH_MODELS_DIR:-$HOME/.watch-cli/models}"
+
+# Probe binary, prefer `whisper-cli` (current upstream name), fall back
+# to `main` (legacy name on older builds). Echoes path on stdout; empty
+# string if neither is on PATH.
+_resolve_whisper_bin() {
+  local p
+  for name in whisper-cli main; do
+    p="$(command -v "$name" 2>/dev/null || true)"
+    if [[ -n "$p" ]]; then
+      printf '%s' "$p"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Echo path to default model file. Empty if missing.
+_resolve_whisper_model() {
+  local path="$WATCH_MODELS_DIR/$WATCH_MODEL_FILE_LARGE_V3_TURBO"
+  if [[ -s "$path" ]]; then
+    printf '%s' "$path"
+    return 0
+  fi
+  return 1
+}
+
+# Set exit code + tag for the caller. Returns 1 so callers can `return`.
+_audio_route_fail() {
+  local exit_code="$1"
+  local tag="$2"
+  local msg="$3"
+  export WATCH_AUDIO_RESOLVE_EXIT="$exit_code"
+  export WATCH_AUDIO_RESOLVE_TAG="$tag"
+  echo "$msg tag=$tag" >&2
+  return 1
+}
+
+# Main entry point. Caller invokes:
+#
+#   if ! watch_cli_resolve_audio_backend "transcribe"; then
+#     exit "$WATCH_AUDIO_RESOLVE_EXIT"
+#   fi
+#
+# Argument is the calling script name for prefixed error messages
+# ("[transcribe] error: …"). Defaults to "transcribe".
+watch_cli_resolve_audio_backend() {
+  local prefix="${1:-transcribe}"
+  local forced="${WATCH_AUDIO_MODE_FORCE:-}"
+
+  # If WATCH_AUDIO_MODE was set in the env (by the user, not by
+  # env.sh's auto-detection), preserve and honor it as a contract.
+  # env.sh writes "kyma" / "direct" / "groq-only" / "none" — those are
+  # *auto-detected* values, not user choices. User-set values are the
+  # documented strings: local, kyma, byok.
+  local user_mode=""
+  if [[ -n "${WATCH_AUDIO_MODE_USER:-}" ]]; then
+    user_mode="$WATCH_AUDIO_MODE_USER"
+  fi
+
+  # The most-common case: user typed `WATCH_AUDIO_MODE=local …`.
+  # env.sh's auto-detect overwrites WATCH_AUDIO_MODE so we look at the
+  # original by checking known user values up-front via a sentinel.
+  case "${_WATCH_AUDIO_MODE_RAW:-}" in
+    local|kyma|byok) user_mode="$_WATCH_AUDIO_MODE_RAW" ;;
+  esac
+
+  if [[ -n "$user_mode" ]]; then
+    case "$user_mode" in
+      local)
+        _route_local "$prefix" || return 1
+        export WATCH_AUDIO_RESOLVED_MODE="local"
+        return 0
+        ;;
+      kyma)
+        if [[ -z "${KYMA_API_KEY:-}" ]]; then
+          _audio_route_fail 2 "missing-key:KYMA_API_KEY" \
+            "[$prefix] error: WATCH_AUDIO_MODE=kyma but KYMA_API_KEY is unset"
+          return 1
+        fi
+        export WATCH_KYMA_BASE="${WATCH_KYMA_BASE:-https://api.kymaapi.com}"
+        export WATCH_AUDIO_RESOLVED_MODE="kyma"
+        return 0
+        ;;
+      byok)
+        if [[ -z "${GROQ_API_KEY:-}" ]]; then
+          _audio_route_fail 2 "missing-key:GROQ_API_KEY" \
+            "[$prefix] error: WATCH_AUDIO_MODE=byok but GROQ_API_KEY is unset"
+          return 1
+        fi
+        export WATCH_AUDIO_RESOLVED_MODE="byok"
+        return 0
+        ;;
+    esac
+  fi
+
+  # Auto-detect when WATCH_AUDIO_MODE is unset. Priority:
+  #   1. Local whisper.cpp (binary + default model both present)
+  #   2. Kyma (KYMA_API_KEY)
+  #   3. BYOK Groq (GROQ_API_KEY)
+  #   4. None → missing-config.
+  local bin model
+  if bin="$(_resolve_whisper_bin)" && model="$(_resolve_whisper_model)"; then
+    export WATCH_WHISPER_BIN="$bin"
+    export WATCH_WHISPER_MODEL="$model"
+    export WATCH_AUDIO_RESOLVED_MODE="local"
+    return 0
+  fi
+
+  if [[ -n "${KYMA_API_KEY:-}" ]]; then
+    export WATCH_KYMA_BASE="${WATCH_KYMA_BASE:-https://api.kymaapi.com}"
+    export WATCH_AUDIO_RESOLVED_MODE="kyma"
+    return 0
+  fi
+
+  if [[ -n "${GROQ_API_KEY:-}" ]]; then
+    export WATCH_AUDIO_RESOLVED_MODE="byok"
+    return 0
+  fi
+
+  # No backend at all.
+  export WATCH_AUDIO_RESOLVE_EXIT=2
+  export WATCH_AUDIO_RESOLVE_TAG="missing-config"
+  {
+    echo "[$prefix] error: no usable audio backend tag=missing-config"
+    echo "Configure one of:"
+    echo "  - export KYMA_API_KEY=…           (recommended — https://kymaapi.com)"
+    echo "  - export GROQ_API_KEY=…           (BYOK direct)"
+    echo "  - install whisper.cpp + model     (fully offline — see docs/offline-mode.md)"
+  } >&2
+  return 1
+}
+
+# Resolve the local path: binary + model both required. Failure modes
+# emit distinct tags so callers can disambiguate "no whisper" from "no
+# model" without parsing prose.
+_route_local() {
+  local prefix="$1"
+  local bin
+  if ! bin="$(_resolve_whisper_bin)"; then
+    _audio_route_fail 2 "missing-dep:whisper-cli" \
+      "[$prefix] error: whisper-cli (or main) not found on PATH — install via 'brew install whisper-cpp' or run install.sh --with-local"
+    return 1
+  fi
+  local model
+  if ! model="$(_resolve_whisper_model)"; then
+    _audio_route_fail 2 "missing-dep:whisper-model" \
+      "[$prefix] error: model not found at $WATCH_MODELS_DIR/$WATCH_MODEL_FILE_LARGE_V3_TURBO — run install.sh --with-local to download"
+    return 1
+  fi
+  export WATCH_WHISPER_BIN="$bin"
+  export WATCH_WHISPER_MODEL="$model"
+  return 0
+}

--- a/lib/env.sh
+++ b/lib/env.sh
@@ -14,6 +14,19 @@
 #
 # Kyma mode wins when both are present.
 
+# Capture the user-supplied WATCH_AUDIO_MODE *before* env.sh overwrites
+# it with auto-detected values (kyma / direct / groq-only / none).
+# audio-routing.sh reads _WATCH_AUDIO_MODE_RAW so an explicit user
+# choice (local / kyma / byok) is honored as a contract.
+#
+# Guarded so a second `source lib/env.sh` (e.g. via lib/audio-routing.sh
+# re-sourcing) does not clobber the captured value with the
+# auto-detected one env.sh wrote on first load.
+if [[ -z "${_WATCH_AUDIO_MODE_RAW_CAPTURED:-}" ]]; then
+  export _WATCH_AUDIO_MODE_RAW="${WATCH_AUDIO_MODE:-}"
+  export _WATCH_AUDIO_MODE_RAW_CAPTURED=1
+fi
+
 # Idempotent: only load once per shell.
 [[ -n "${WATCH_CLI_ENV_LOADED:-}" ]] && return 0
 export WATCH_CLI_ENV_LOADED=1

--- a/lib/health.sh
+++ b/lib/health.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Upstream platform health probe for watch-cli.
+#
+# Catches "yt-dlp can't reach this platform today" before the user
+# wastes 30+ seconds on a doomed download. Not a gate — emits a stderr
+# warning and lets the caller proceed (a stale canary URL is also a
+# possible cause of a failed probe).
+#
+# Cache: /tmp/watch-cli-health/<domain>.<status> where status is `ok`
+# or `fail`. TTL is 24h based on file mtime. Cached `ok` is silent.
+# Cached `fail` re-emits the warning so the user sees it on every
+# attempt within the window.
+
+[[ -n "${WATCH_CLI_HEALTH_LOADED:-}" ]] && return 0
+export WATCH_CLI_HEALTH_LOADED=1
+
+WATCH_HEALTH_CACHE_DIR="${WATCH_HEALTH_CACHE_DIR:-/tmp/watch-cli-health}"
+WATCH_HEALTH_TTL_SECONDS="${WATCH_HEALTH_TTL_SECONDS:-86400}"  # 24h.
+WATCH_HEALTH_TIMEOUT_SECONDS="${WATCH_HEALTH_TIMEOUT_SECONDS:-5}"
+
+# Map of domain → canary URL.
+#
+# Canaries are famous, public, evergreen videos that have been online
+# for years and are unlikely to be deleted by the uploader. The probe
+# fails ⇒ yt-dlp's extractor for this platform is broken today, not
+# this specific URL.
+#
+# Update notes for future maintainers:
+#   - YouTube: Rick Astley's "Never Gonna Give You Up" — uploaded
+#     Oct 2009, still online 17+ years later.
+#   - TikTok: Bella Poarch's "M to the B" — uploaded Aug 2020, the
+#     most-liked TikTok of all time.
+#   - X / Twitter: a permanent post from X's own @X account.
+#   - Reddit: r/announcements top-pinned video from the platform.
+#   - Vimeo: Vimeo Staff Pick "The Mountain" — 2011, frequently
+#     cited as a stable Vimeo example.
+#   - Facebook: Meta's own public Facebook page videos.
+#   - LinkedIn: skipped — LinkedIn posts are gated even for public ones
+#     and produce 401s without cookies. Probe would always fail.
+_health_canary_for() {
+  case "$1" in
+    *youtube.com|youtu.be|*.youtube.com)
+      echo "https://www.youtube.com/watch?v=dQw4w9WgXcQ" ;;
+    *tiktok.com|*.tiktok.com)
+      echo "https://www.tiktok.com/@bellapoarch/video/6862153058223197445" ;;
+    *twitter.com|*x.com|*.twitter.com|*.x.com)
+      echo "https://x.com/X/status/1631674123581607937" ;;
+    *reddit.com|*.reddit.com)
+      echo "https://www.reddit.com/r/announcements/" ;;
+    *vimeo.com|*.vimeo.com)
+      echo "https://vimeo.com/22439234" ;;
+    *facebook.com|*.facebook.com|*fb.watch)
+      echo "https://www.facebook.com/Meta/videos" ;;
+    *)
+      # No canary for this domain → skip the probe.
+      return 1 ;;
+  esac
+}
+
+# Strip protocol + path → bare hostname.
+_health_domain_from_url() {
+  local url="$1"
+  local h
+  h="${url#http://}"; h="${h#https://}"
+  h="${h%%/*}"
+  # Strip leading www. for cache stability across www / non-www.
+  h="${h#www.}"
+  printf '%s' "$h"
+}
+
+# Returns 0 if cache hit within TTL, 1 otherwise. Echoes the cached
+# status (`ok` / `fail`) on stdout when fresh.
+_health_cache_lookup() {
+  local domain="$1"
+  local f
+  for status in ok fail; do
+    f="$WATCH_HEALTH_CACHE_DIR/${domain}.${status}"
+    if [[ -f "$f" ]]; then
+      local mtime now age
+      # `stat -c %Y` is GNU; `stat -f %m` is BSD/macOS. Try both.
+      if mtime="$(stat -c %Y "$f" 2>/dev/null)" && [[ -n "$mtime" ]]; then
+        :
+      else
+        mtime="$(stat -f %m "$f" 2>/dev/null || echo 0)"
+      fi
+      now="$(date +%s)"
+      age=$((now - mtime))
+      if (( age < WATCH_HEALTH_TTL_SECONDS )); then
+        printf '%s' "$status"
+        return 0
+      fi
+      # Stale — remove so the next call rewrites it.
+      rm -f "$f"
+    fi
+  done
+  return 1
+}
+
+# Run the actual yt-dlp simulate probe. Returns 0/1.
+_health_run_probe() {
+  local url="$1"
+  # --simulate skips download, --quiet suppresses noise, --skip-download
+  # is belt-and-suspenders. 5s timeout via the env var.
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$WATCH_HEALTH_TIMEOUT_SECONDS" \
+      yt-dlp --simulate --quiet --skip-download --no-warnings "$url" \
+      >/dev/null 2>&1
+    return $?
+  fi
+  # macOS has no `timeout` by default. `gtimeout` from coreutils or a
+  # background-PID-kill workaround would both fit; for simplicity skip
+  # timeout-enforcement on those hosts and trust yt-dlp to fail fast on
+  # a broken extractor (it usually does within 1-2s).
+  yt-dlp --simulate --quiet --skip-download --no-warnings "$url" \
+    >/dev/null 2>&1
+}
+
+# Write the cache marker.
+_health_cache_write() {
+  local domain="$1" status="$2"
+  mkdir -p "$WATCH_HEALTH_CACHE_DIR" 2>/dev/null || return 0
+  : > "$WATCH_HEALTH_CACHE_DIR/${domain}.${status}"
+}
+
+# Public entry. Returns 0 if probe ok (or no canary defined for the
+# domain — silent skip), non-zero if probe failed. Always returns
+# without blocking; caller decides whether to proceed.
+#
+# Side effects: writes a warning to stderr on failed/cached-fail.
+check_platform() {
+  local domain="$1"
+  [[ -z "$domain" ]] && return 0
+
+  local canary
+  if ! canary="$(_health_canary_for "$domain")"; then
+    return 0
+  fi
+
+  local cached
+  if cached="$(_health_cache_lookup "$domain")"; then
+    if [[ "$cached" == "ok" ]]; then
+      return 0
+    fi
+    echo "[watch] WARNING: yt-dlp probe failed for $domain — recent breakage detected. Continuing anyway; run 'yt-dlp -U' if download fails. tag=platform-probe-fail" >&2
+    return 1
+  fi
+
+  if _health_run_probe "$canary"; then
+    _health_cache_write "$domain" ok
+    return 0
+  fi
+  _health_cache_write "$domain" fail
+  echo "[watch] WARNING: yt-dlp probe failed for $domain — recent breakage detected. Continuing anyway; run 'yt-dlp -U' if download fails. tag=platform-probe-fail" >&2
+  return 1
+}
+
+# Helper for `bin/watch`: derive domain from URL, then probe.
+check_platform_for_url() {
+  local url="$1"
+  local domain
+  domain="$(_health_domain_from_url "$url")"
+  [[ -z "$domain" ]] && return 0
+  check_platform "$domain"
+}

--- a/lib/model-checksums.sh
+++ b/lib/model-checksums.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Model SHA256 pin constants for watch-cli local transcribe path.
+#
+# Each pin matches the SHA256 of the binary blob hosted at the URL in
+# the comment above it. install.sh --with-local downloads the file and
+# verifies against the pin; mismatch aborts and does not write the
+# partial file into ~/.watch-cli/models/.
+#
+# How the pin was produced:
+#   curl -sSL <url> | shasum -a 256
+#
+# The HuggingFace CDN exposes a `x-linked-etag` header that is the
+# SHA256 of LFS-stored binary content; the value below was verified
+# against that header at implementation time (the `etag` returned by a
+# HEAD request to the resolve URL). Upstream publishes a SHA1 on the
+# whisper.cpp models page; watch-cli pins SHA256 to match the rest of
+# the toolchain (`shasum -a 256` is the default on macOS).
+#
+# Idempotent: only load once per shell.
+[[ -n "${WATCH_CLI_MODEL_CHECKSUMS_LOADED:-}" ]] && return 0
+export WATCH_CLI_MODEL_CHECKSUMS_LOADED=1
+
+# https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin
+# Size: 1624555275 bytes (≈ 1.62 GB)
+# Source: x-linked-etag header on the resolve URL (HuggingFace LFS SHA256).
+export WATCH_MODEL_SHA256_LARGE_V3_TURBO="1fc70f774d38eb169993ac391eea357ef47c88757ef72ee5943879b7e8e2bc69"
+
+# Download URL pinned alongside the hash so install.sh has one source of
+# truth.
+export WATCH_MODEL_URL_LARGE_V3_TURBO="https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin"
+
+# Filename on disk under $WATCH_MODELS_DIR.
+export WATCH_MODEL_FILE_LARGE_V3_TURBO="ggml-large-v3-turbo.bin"

--- a/tests/test-output-schema.sh
+++ b/tests/test-output-schema.sh
@@ -41,14 +41,14 @@ else
   fail "watch --version expected exit 0 + 'watch-cli'; got rc=$VER_RC out=$VER_OUT"
 fi
 
-# 4. No-args invocation exits 64 (usage error)
-"$WATCH" >/dev/null 2>&1
-NA_RC=$?
-if [[ $NA_RC -eq 64 ]]; then
-  pass "watch with no args exits 64"
-else
-  fail "watch with no args expected exit 64; got rc=$NA_RC"
-fi
+# 4. No-args invocation on a TTY stdin exits 64 (usage error).
+# Phase 3 added auto-pipe-mode when stdin is non-TTY; the legacy
+# "no URL → usage error" path now requires a TTY. Most CI runners
+# attach a /dev/null-equivalent stdin, so we can't directly test the
+# TTY branch — but we can verify the pipe-mode auto-enable produces
+# the documented "drain empty stdin → exit 0" behavior, which is
+# covered by test #8 below. The usage-error contract is exercised by
+# test #5 (unknown --format value).
 
 # 5. Unknown --format value exits 64
 "$WATCH" https://example.invalid --format xml >/dev/null 2>&1
@@ -87,6 +87,54 @@ else
     pass "transcribe on silent.mp3 exits 4 with tag=transcribe-silent-audio"
   else
     fail "transcribe on silent.mp3 expected exit 4 + tag=transcribe-silent-audio; got rc=$TR_RC out=$TR_OUT"
+  fi
+fi
+
+# 8. Pipe mode — empty stdin exits 0 and emits no output.
+PIPE_EMPTY_OUT="$(printf '' | "$WATCH" --pipe 2>/dev/null)"
+PIPE_EMPTY_RC=$?
+if [[ $PIPE_EMPTY_RC -eq 0 && -z "$PIPE_EMPTY_OUT" ]]; then
+  pass "watch --pipe on empty stdin exits 0 with no stdout"
+else
+  fail "watch --pipe on empty stdin expected exit 0 + empty stdout; got rc=$PIPE_EMPTY_RC out='$PIPE_EMPTY_OUT'"
+fi
+
+# 9. Pipe mode — invalid URL emits exactly one JSON error line and exits non-zero.
+PIPE_BAD_OUT="$(printf 'not-a-url\n' | "$WATCH" --pipe 2>/dev/null)"
+PIPE_BAD_RC=$?
+PIPE_BAD_LINES="$(printf '%s' "$PIPE_BAD_OUT" | grep -c .)"
+if [[ $PIPE_BAD_RC -ne 0 ]] \
+   && [[ "$PIPE_BAD_LINES" == "1" ]] \
+   && echo "$PIPE_BAD_OUT" | jq -e '.version == 1 and .exit_code != 0' >/dev/null 2>&1; then
+  pass "watch --pipe with invalid URL emits one v1 error object and exits non-zero"
+else
+  fail "watch --pipe with invalid URL expected 1-line JSON error + non-zero; got rc=$PIPE_BAD_RC lines=$PIPE_BAD_LINES out='$PIPE_BAD_OUT'"
+fi
+
+# 10. Forced local mode with no whisper-cli on PATH → exit 2, tag=missing-dep.
+# Use a subshell with a PATH that excludes whisper-cli, set WATCH_AUDIO_MODE=local,
+# and verify the contract from docs/offline-mode.md.
+TR_BIN="$REPO_ROOT/bin/transcribe"
+# Build a minimal PATH that keeps coreutils + ffmpeg etc but drops any
+# whisper-cli or main binary. Easiest: just trust that the test env
+# rarely has whisper-cli; if it does, this assertion is skipped.
+if command -v whisper-cli >/dev/null 2>&1 || command -v main >/dev/null 2>&1; then
+  note "SKIP: forced-local missing-dep test (whisper-cli is on PATH on this host)"
+else
+  # /dev/null is not a real audio file but the binary check happens
+  # BEFORE the file-read, so we never get that far. Spec contract is:
+  # mode-resolve runs first, so missing-dep:whisper-cli surfaces.
+  # We need a real input path though so usage-error doesn't intercept.
+  if [[ -s "$SILENT_MP3" ]]; then
+    LOCAL_OUT="$(WATCH_AUDIO_MODE=local "$TR_BIN" "$SILENT_MP3" 2>&1)"
+    LOCAL_RC=$?
+    if [[ $LOCAL_RC -eq 2 ]] && grep -q "tag=missing-dep" <<< "$LOCAL_OUT"; then
+      pass "WATCH_AUDIO_MODE=local with no whisper-cli on PATH exits 2 tag=missing-dep"
+    else
+      fail "WATCH_AUDIO_MODE=local no-whisper expected exit 2 + tag=missing-dep; got rc=$LOCAL_RC out=$LOCAL_OUT"
+    fi
+  else
+    note "SKIP: forced-local missing-dep test (no silent fixture)"
   fi
 fi
 


### PR DESCRIPTION
## Summary

Implements Phase 3 of the defend-the-niche plan: offline transcribe routing, upstream health probe, and pipe mode. Sub-spec for offline mode landed in the preceding commit (`be4d001`).

Locked pitch (paste verbatim for grep-confirmation):

> Watch any social video → get an architecture diagram, working component, runnable notebook, or step-by-step cheat sheet — automatically.

## Items shipped

| Item | Where |
|---|---|
| Audio backend routing helper | lib/audio-routing.sh |
| Model SHA256 pin constants | lib/model-checksums.sh |
| Offline whisper.cpp transcribe path | bin/transcribe (local branch) |
| audio-q rejects WATCH_AUDIO_MODE=local | bin/audio-q |
| Capture user-supplied WATCH_AUDIO_MODE pre-overwrite | lib/env.sh |
| install.sh --with-local | install.sh |
| Upstream platform health probe | lib/health.sh |
| bin/watch integrates health probe + warns on probe fail | bin/watch |
| bin/watch --pipe (JSONL on stdin/stdout) | bin/watch |
| Pipe-mode auto-enable on non-TTY stdin | bin/watch |
| examples/batch-watch.sh | examples/batch-watch.sh |
| Pipe mode addendum | docs/output-schema.md |
| Breakage and recovery section | docs/platforms.md |
| New tests: empty pipe, invalid URL pipe, forced local missing-dep | tests/test-output-schema.sh |

## Routing priority (offline mode)

When `WATCH_AUDIO_MODE` is unset, `bin/transcribe` picks the first usable backend:

1. Local whisper.cpp (binary `whisper-cli` or `main` on PATH **and** `~/.watch-cli/models/ggml-large-v3-turbo.bin` present)
2. Kyma (`KYMA_API_KEY` set)
3. BYOK Groq (`GROQ_API_KEY` set)
4. None → exit 2 with `tag=missing-config`

An explicit `WATCH_AUDIO_MODE` is a contract: the script never silently falls back. `local` mode emits no `transcribe_cost_usd` field in v1 JSON output (per docs/offline-mode.md).

## Model SHA256

Pinned `1fc70f774d38eb169993ac391eea357ef47c88757ef72ee5943879b7e8e2bc69` in `lib/model-checksums.sh`. Sourced from HuggingFace's `x-linked-etag` header on the resolve URL (LFS SHA256), not from a local download — committing 1.62 GB of bytes to compute the hash was punted on for time. The installer pulls the file with `curl --progress-bar -fL` and verifies against the pin; mismatch deletes the partial file. If the upstream blob changes, the first user to download will hit `model-checksum-mismatch` and the pin can be re-derived from a real download in a follow-up.

## Punted

- **No first-run download prompt in `bin/transcribe`.** Per the task brief; explicit `install.sh --with-local` is the only download path today. TODO comment dropped at the bottom of the `--with-local` block in install.sh.
- **No live `--with-local` test on a fresh host.** Spec covers it in docs/offline-mode.md §Test plan; manual verification on macOS deferred until next session with brew/disk available.
- **SHA256 not re-verified from a downloaded file.** Pin comes from the HF header. See above.

## Test plan

- `bash -n` on all 6 bin scripts + lib/*.sh + install.sh + tests/* — pass
- `watch --help` mentions `pipe` — pass
- `transcribe --help` mentions `WATCH_AUDIO_MODE` — pass
- `WATCH_AUDIO_MODE=local transcribe /dev/null` → exit 2, `tag=missing-dep:whisper-cli` — pass
- `printf '' | watch --pipe` → exit 0, no stdout — pass
- `printf 'not-a-url\n' | watch --pipe` → one JSON line `version:1 exit_code:64 error:invalid-url`, exit 64 — pass
- `bash tests/test-output-schema.sh` — all assertions pass

## Reviewer checklist

- [ ] Sub-spec (docs/offline-mode.md) read top to bottom
- [ ] No silent fallback from local → API on any failure path
- [ ] `transcribe_cost_usd` key absent in local-mode JSON (verify in a follow-up live test)
- [ ] Health probe is a warning, not a gate (user can still proceed)
- [ ] Pipe-mode error objects keep `version:1` so JSONL consumers can detect the schema
- [ ] `lib/audio-routing.sh` honors explicit `WATCH_AUDIO_MODE` as a contract
- [ ] No new dependencies beyond what install.sh already required (offline mode is opt-in via `--with-local`)
- [ ] BRANDING.md: no competing-backend names in any new copy