### PR TITLE
feat(phase-5): Claude Code skill marketplace install path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "watch-cli",
+  "owner": {
+    "name": "Son Piaz",
+    "email": "sonxpiaz@gmail.com"
+  },
+  "metadata": {
+    "description": "watch-cli skill marketplace — Claude Code users can /plugin install watch-cli.",
+    "version": "0.3.0"
+  },
+  "plugins": [
+    {
+      "name": "watch-cli",
+      "description": "Compose yt-dlp + ffmpeg + Whisper into a single command that hands an AI agent the raw materials to watch any social video — VIDEO + FRAMES + TRANSCRIPT, ready for an LLM to read frames as images and transcript as text.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/watch-cli"
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ signup is enough to run the full pipeline end-to-end before you spend a cent.
 ## Install
 
 ```bash
-# macOS — Homebrew (recommended once v0.3.0 ships)
+# macOS — Homebrew (recommended)
 brew tap sonpiaz/tap
 brew install watch-cli
 
@@ -101,9 +101,19 @@ brew install watch-cli
 curl -fsSL https://github.com/sonpiaz/watch-cli/releases/latest/download/install.sh | bash
 ```
 
-> The Homebrew path requires the v0.3.0 release to be cut first.
-> Until then, use the curl one-liner above — it auto-falls-back to
-> `git clone` of `main` when no published release exists yet.
+> The curl one-liner auto-falls back to `git clone` of `main` if no
+> published release tarball is reachable.
+
+### Claude Code (skill marketplace)
+
+If you use Claude Code, install watch-cli as a skill:
+
+```
+/plugin marketplace add sonpiaz/watch-cli
+/plugin install watch-cli@watch-cli
+```
+
+The agent then picks up `watch <url>` as a first-class command.
 
 Pin a specific version:
 


### PR DESCRIPTION
## Summary

Adds \`.claude-plugin/marketplace.json\` so Claude Code users can install watch-cli as a skill via:

\`\`\`
/plugin marketplace add sonpiaz/watch-cli
/plugin install watch-cli@watch-cli
\`\`\`

The marketplace.json points at the existing \`skills/watch-cli/SKILL.md\` (symlinked from the repo-root canonical SKILL.md authored in Phase 2). No new skill content — this is purely the plumbing that makes the existing portable SKILL.md installable through Claude Code's plugin manager without manual \`cp -r ~/.claude/skills/\`.

## Files changed

| File | Change |
|---|---|
| \`.claude-plugin/marketplace.json\` (new) | Marketplace manifest pointing at \`./skills/watch-cli\` |
| \`README.md\` Install section | Adds Claude Code subsection; removes the now-obsolete "requires v0.3.0 to be cut first" caveat since v0.3.0 has shipped |

## Why this matters

Phase 2 shipped a portable \`SKILL.md\` valid in Claude Code + OpenClaw + Hermes. Until this PR, Claude Code users had to:

\`\`\`
git clone https://github.com/sonpiaz/watch-cli ~/.claude/skills/watch-cli
\`\`\`

After this PR, two slash commands handle it.

## Test plan

- [ ] Render README on GitHub, confirm new Claude Code subsection
- [ ] Verify \`/plugin marketplace add sonpiaz/watch-cli\` resolves the manifest (will work once PR is merged + on \`main\`)
- [ ] No regressions in existing brew/curl install paths