### PR TITLE
feat(phase-5): v0.3.1 — add mcpName for MCP Registry

### DIFF
--- a/lib/version.sh
+++ b/lib/version.sh
@@ -12,5 +12,5 @@
 # titled `release: vX.Y.Z`, merge, then tag the merge commit `vX.Y.Z`
 # and push. The tag fires the release workflow.
 
-export WATCH_CLI_VERSION="0.3.0"
+export WATCH_CLI_VERSION="0.3.1"
 export WATCH_CLI_VERSION_STRING="watch-cli v${WATCH_CLI_VERSION}"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@sonpiaz/watch-cli-mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
+  "mcpName": "io.github.sonpiaz/watch-cli",
   "description": "Watch any social video → get an architecture diagram, working component, runnable notebook, or step-by-step cheat sheet — automatically. MCP stdio server for watch-cli.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Two-line change to enable submission to the official [MCP Server Registry](https://registry.modelcontextprotocol.io) (replaces the retired third-party list in \`modelcontextprotocol/servers\` README).

| File | Change |
|---|---|
| \`mcp-server/package.json\` | Add \`mcpName: "io.github.sonpiaz/watch-cli"\`; bump version 0.3.0 → 0.3.1 |
| \`lib/version.sh\` | Bump WATCH_CLI_VERSION 0.3.0 → 0.3.1 |

The \`mcpName\` field is the GitHub-based ownership verification mechanism required by the MCP registry. It must start with \`io.github.<owner>/\` to prove the npm publisher controls the matching GitHub account.

## Post-merge sequence (maintainer)

1. Tag \`v0.3.1\` on the merge commit and push → release workflow auto-republishes \`@sonpiaz/watch-cli-mcp@0.3.1\` to npm with the \`mcpName\` field.
2. Install \`mcp-publisher\` CLI: \`brew install mcp-publisher\`.
3. \`cd mcp-server && mcp-publisher init\` to generate \`server.json\`.
4. \`mcp-publisher login\` (interactive GitHub OAuth — runs in your terminal, not CI).
5. \`mcp-publisher publish\` to register the server.

Once steps 1–5 complete, the server appears in [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io) and is discoverable by every MCP-capable agent that consumes the registry.

## Why this isn't done by CI

The publish step needs interactive GitHub OAuth. Automating it would require a long-lived OAuth token, which mcp-publisher does not yet support. Once the registry exposes a CI-friendly token flow, the release workflow can chain step 5.

## Test plan

- [ ] \`./bin/watch --version\` reports \`watch-cli v0.3.1\` after this branch checks out
- [ ] CI smoke matrix stays green
- [ ] No other version refs missed (lib/version.sh + mcp-server/package.json are the only canonical spots; README install snippets still reference v0.3.0 — those don't gate this PR but should be bumped post-tag in a follow-up)