### PR TITLE
release: v0.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ The agent then picks up `watch <url>` as a first-class command.
 Pin a specific version:
 
 ```bash
-WATCH_CLI_VERSION=0.3.0 curl -fsSL \
-  https://github.com/sonpiaz/watch-cli/releases/download/v0.3.0/install.sh | bash
+curl -fsSL https://github.com/sonpiaz/watch-cli/releases/download/v0.3.3/install.sh \
+  | WATCH_CLI_VERSION=0.3.3 bash
 ```
 
 Or from a clone:
@@ -257,9 +257,11 @@ to see what's behind the alias today.
 Most YouTube / TikTok / Reddit / Vimeo / public X work without setup.
 LinkedIn, private X posts, and Facebook need a session.
 
-watch-cli auto-detects cookies from any signed-in browser
+watch-cli tries every URL anonymously first. On a login wall it
+retries with cookies from a signed-in browser on this machine
 (Chrome → Firefox → Safari → Edge → Brave → Chromium). Just sign in
-normally and re-run.
+normally and re-run. `WATCH_BROWSER=none` turns the browser step off;
+cookies are read locally by yt-dlp and never stored or uploaded.
 
 For servers / CI without browsers, pass a manual cookies file:
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -9,12 +9,18 @@ metadata:
       bins:
         - watch
     install:
-      - id: curl-install
-        kind: shell
-        command: "curl -fsSL https://raw.githubusercontent.com/sonpiaz/watch-cli/main/install.sh | bash"
+      - id: brew
+        kind: brew
+        formula: sonpiaz/tap/watch-cli
         bins:
           - watch
-        label: "Install watch-cli (curl)"
+        label: "Install watch-cli (Homebrew)"
+      - id: release-0.3.3
+        kind: shell
+        command: "curl -fsSL https://github.com/sonpiaz/watch-cli/releases/download/v0.3.3/install.sh | WATCH_CLI_VERSION=0.3.3 bash"
+        bins:
+          - watch
+        label: "Install watch-cli v0.3.3 (pinned release, SHA256-verified tarball)"
 ---
 
 Watch any social video → get an architecture diagram, working component, runnable notebook, or step-by-step cheat sheet — automatically.
@@ -30,7 +36,7 @@ Reach for `watch` whenever the user gives you a video URL and wants you to do so
 - The user asks to "implement", "clone", "build", or "replicate" what is on screen in a video.
 - The user asks to "extract architecture from", "diagram", or "turn this paper talk into code" at a video URL.
 
-Supported platforms: YouTube, X / Twitter, LinkedIn, TikTok, Vimeo, Reddit, Facebook. Login-walled sources fall back to the user's signed-in browser cookies automatically.
+Supported platforms: YouTube, X / Twitter, LinkedIn, TikTok, Vimeo, Reddit, Facebook. Every URL is fetched anonymously first. Only when the platform answers with a login wall does `watch` retry with the cookies of a browser the user is already signed in to on this machine (Chrome, Firefox, Safari, Edge, Brave, Chromium, in that order); `WATCH_BROWSER=none` turns that step off and `--cookies <file>` replaces it with an exported cookie file. Cookies are read from the local browser profile by yt-dlp and sent only to the platform that issued them; watch-cli never stores or uploads them.
 
 ## What you get back
 
@@ -88,5 +94,12 @@ Pass `--no-cache` only when the source itself has changed. A failed transcriptio
 - Do not hard-fail on every non-zero exit. `exit 4` is recoverable partial success — frames populated, transcript `null`. Branch on `exit_code` before parsing.
 - Do not surface API keys or environment variable names in chat. `KYMA_API_KEY` setup lives in the README.
 - Do not embed the locked pitch into a longer marketing paragraph. The description line above is the source of truth; reuse it verbatim where the host shows skill metadata.
+
+## What leaves the machine
+
+- The video download goes to the platform hosting it, through yt-dlp.
+- The extracted audio track is uploaded to Kyma API for transcription; frames and the video file stay on disk under `~/.watch-cli/archive`. With `--with-local` installed, transcription runs offline through whisper.cpp instead and nothing is uploaded.
+- Browser cookies, when used, go only to the platform that set them (see above).
+- Installation is pinned: the release installer downloads a tagged tarball and verifies its SHA256 against the checksum published on the same GitHub Release. Homebrew does the same through the formula's `sha256`.
 
 Transcription runs through Kyma API. Get a key at https://kymaapi.com/?src=skill:watch and set `KYMA_API_KEY`; a one-hour video costs about $0.05.

--- a/bin/dl-video
+++ b/bin/dl-video
@@ -149,15 +149,20 @@ fi
 
 # Tier 2: auto-detect signed-in browser.
 # Order: Chrome → Firefox → Safari → Edge → Brave → Chromium.
-# Override via env: WATCH_BROWSER=firefox.
+# Override via env: WATCH_BROWSER=firefox. WATCH_BROWSER=none skips
+# this tier entirely, so a login wall fails with tag=download-auth
+# instead of touching any browser profile.
 declare -a BROWSERS
-if [[ -n "${WATCH_BROWSER:-}" ]]; then
+if [[ "${WATCH_BROWSER:-}" == "none" ]]; then
+  BROWSERS=()
+elif [[ -n "${WATCH_BROWSER:-}" ]]; then
   BROWSERS=("$WATCH_BROWSER")
 else
   BROWSERS=(chrome firefox safari edge brave chromium)
 fi
 
-for BROWSER in "${BROWSERS[@]}"; do
+# ${arr[@]+"${arr[@]}"} keeps `set -u` happy on an empty array (bash 3.2).
+for BROWSER in ${BROWSERS[@]+"${BROWSERS[@]}"}; do
   echo "[dl-video] anonymous fetch failed, retrying with $BROWSER cookies…" >&2
   if run_dl --cookies-from-browser "$BROWSER" 2>/tmp/dl-video.last.log; then
     if [[ -s "$OUT" ]]; then

--- a/docs/cookies.md
+++ b/docs/cookies.md
@@ -34,6 +34,16 @@ To force a specific browser:
 WATCH_BROWSER=firefox watch <url>
 ```
 
+To never touch a browser profile (servers, shared machines, or when you
+would rather see a login wall fail than have a session reused):
+
+```bash
+WATCH_BROWSER=none watch <url>
+```
+
+The download then stops at `tag=download-auth` for login-walled URLs;
+pass `--cookies <file>` if you still need them.
+
 ### Why this works
 
 `yt-dlp` reads cookies directly from your browser's local profile. The

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -287,8 +287,8 @@ tagged release tarball.
 curl -fsSL https://github.com/sonpiaz/watch-cli/releases/latest/download/install.sh | bash
 
 # pin a specific version
-WATCH_CLI_VERSION=0.3.0 curl -fsSL \
-  https://github.com/sonpiaz/watch-cli/releases/download/v0.3.0/install.sh | bash
+curl -fsSL https://github.com/sonpiaz/watch-cli/releases/download/v0.3.3/install.sh \
+  | WATCH_CLI_VERSION=0.3.3 bash
 ```
 
 `releases/latest/download/<asset>` is a GitHub-managed redirect that
@@ -350,7 +350,7 @@ The implementer must verify end to end before declaring done:
    against `watch-cli.tar.gz.sha256`, unpack and run
    `./watch-cli-0.3.0/install.sh` on a clean container. `watch
    --version` prints `watch-cli v0.3.0`.
-3. **Pinned install.** Run the `WATCH_CLI_VERSION=0.3.0` curl form
+3. **Pinned install.** Run the `WATCH_CLI_VERSION=0.3.3` curl form (the variable goes on the `bash` side of the pipe)
    on a second clean container. Same result.
 4. **Latest install.** Run the `releases/latest/download/install.sh`
    form. Resolves to v0.3.0.

--- a/install.sh
+++ b/install.sh
@@ -3,8 +3,8 @@
 # Usage:
 #   curl -fsSL https://github.com/sonpiaz/watch-cli/releases/latest/download/install.sh | bash
 # or pin a version:
-#   WATCH_CLI_VERSION=0.3.0 curl -fsSL \
-#     https://github.com/sonpiaz/watch-cli/releases/download/v0.3.0/install.sh | bash
+#   curl -fsSL https://github.com/sonpiaz/watch-cli/releases/download/v0.3.3/install.sh \
+#     | WATCH_CLI_VERSION=0.3.3 bash
 # or, from a clone:
 #   ./install.sh
 #
@@ -52,12 +52,13 @@ watch-cli installer
 
 Usage:
   curl -fsSL https://github.com/sonpiaz/watch-cli/releases/latest/download/install.sh | bash
-  WATCH_CLI_VERSION=0.3.0 curl -fsSL \
-    https://github.com/sonpiaz/watch-cli/releases/download/v0.3.0/install.sh | bash
+  curl -fsSL https://github.com/sonpiaz/watch-cli/releases/download/v0.3.3/install.sh \
+    | WATCH_CLI_VERSION=0.3.3 bash
   ./install.sh [--with-skill] [--with-mcp] [--with-local]
 
 Env:
-  WATCH_CLI_VERSION  Pin to a specific release (e.g. 0.3.0).
+  WATCH_CLI_VERSION  Pin to a specific release (e.g. 0.3.3). Set it on
+                     the bash side of the pipe, not on curl.
                      Unset → install the latest release.
 
 Flags:

--- a/lib/version.sh
+++ b/lib/version.sh
@@ -12,5 +12,5 @@
 # titled `release: vX.Y.Z`, merge, then tag the merge commit `vX.Y.Z`
 # and push. The tag fires the release workflow.
 
-export WATCH_CLI_VERSION="0.3.2"
+export WATCH_CLI_VERSION="0.3.3"
 export WATCH_CLI_VERSION_STRING="watch-cli v${WATCH_CLI_VERSION}"


### PR DESCRIPTION
Patch release: install pinning, cookie policy, and one installer bug.

## Why
ClawHub's security review of the `watch-cli` skill (1.0.0) came back "suspicious" for two reasons: the install command piped `main/install.sh` into bash with no version pin, and the skill said login-walled sources "fall back to the user's signed-in browser cookies automatically" without saying when, from where, or how to turn it off. Both are fixable in the skill and the docs.

## What changed
- **SKILL.md install**: Homebrew (`sonpiaz/tap/watch-cli`) first, then the v0.3.3 release installer. `install.sh` already verifies the tarball SHA256 against the checksum on the same GitHub Release.
- **Cookie policy**: anonymous fetch first; browser cookies only on a login wall; read locally by yt-dlp, sent only to the platform that set them, never stored or uploaded. `WATCH_BROWSER=none` skips the browser tier (`bin/dl-video`, README, `docs/cookies.md`).
- **"What leaves the machine"** section in SKILL.md.
- **Installer bug**: `WATCH_CLI_VERSION=0.3.0 curl … | bash` set the variable on `curl`, so the "pinned" form installed latest. Corrected to `curl … | WATCH_CLI_VERSION=0.3.3 bash` in README, `install.sh` usage and `docs/releases.md`.
- `lib/version.sh` → 0.3.3 (patch per `docs/releases.md`: no output-schema change; `WATCH_BROWSER` already existed, `none` is a new accepted value).

## Verified
- `bash -n` on `bin/dl-video` and `install.sh`.
- `WATCH_BROWSER=chrome bin/dl-video https://nonexistent.invalid/…` prints "retrying with chrome cookies"; `WATCH_BROWSER=none` goes straight to `tag=download-other`.

After merge: tag `v0.3.3` on the merge commit → release workflow builds the tarball, publishes the npm MCP package, and opens the Homebrew tap bump PR. Then republish the ClawHub skill as 1.0.1 from the tagged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Rok2mujdEZ2yGw8wVfbr9
