### PR TITLE
chore(release): npm publish step no longer fails the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,12 @@ jobs:
     name: Publish @sonpiaz/watch-cli-mcp to npm
     needs: release
     runs-on: ubuntu-latest
+    # npm granular tokens expire every 90 days and the release must not hang
+    # on one. A red step here means "publish by hand": from mcp-server/,
+    # `npm version --no-git-tag-version <tag>`, `npm ci`, `npm run build`,
+    # `npm publish --access public` with a logged-in npm account (v0.3.4 was
+    # published that way on 2026-09-05).
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -24,6 +24,21 @@ contract: "v1 means the tarball at tag v1.x.y."
 
 ---
 
+## When the npm step is red
+
+The `Publish @sonpiaz/watch-cli-mcp to npm` job is `continue-on-error`: npm
+granular tokens expire every 90 days and a release should not fail because a
+secret aged out. When it is red, publish by hand from a checkout of the tag:
+
+```bash
+cd mcp-server
+npm version --no-git-tag-version X.Y.Z
+npm ci && npm run build
+npm publish --access public
+```
+
+Then refresh `NPM_TOKEN` in the repository secrets when convenient.
+
 ## Semver policy
 
 watch-cli follows semver with one pre-1.0 exception (see below).


### PR DESCRIPTION
npm granular tokens expire every 90 days; v0.3.3 and v0.3.4 went red only on that step and were published by hand. The step is now continue-on-error and docs/releases.md says how to publish by hand when it is red.